### PR TITLE
Add consultant dropdown loaded from sheet

### DIFF
--- a/Consultants.gs
+++ b/Consultants.gs
@@ -1,0 +1,16 @@
+/* ===== 照專名單：依單位代碼取得在職照專姓名 ===== */
+function getConsultantsByUnit(unit) {
+  if (!unit) return [];
+  const ss = SpreadsheetApp.openById(CONSULTANTS_BOOK_ID);
+  const sheet = ss.getSheetByName(CONSULTANTS_BOOK_NAME);
+  if (!sheet) return [];
+  const rows = sheet.getDataRange().getValues();
+  const names = [];
+  for (let i = 1; i < rows.length; i++) {
+    const [unitCode, name, status] = rows[i];
+    if (unitCode === unit && status === '在職') {
+      names.push(name);
+    }
+  }
+  return names;
+}

--- a/HTML
+++ b/HTML
@@ -45,7 +45,7 @@
     <div class="row">
       <div>
         <label>單位代碼</label>
-        <select id="unitCode" onchange="loadManagers()">
+        <select id="unitCode" onchange="loadManagers(); loadConsultants();">
           <option>FNA1</option><option>FNA2</option><option>FNA3</option>
         </select>
       </div>
@@ -61,7 +61,9 @@
       </div>
       <div>
         <label>照專姓名</label>
-        <input id="consultName" type="text" placeholder="請輸入">
+        <select id="consultName">
+          <option value="" class="placeholder-option" disabled selected>請選擇</option>
+        </select>
       </div>
     </div>
   </div>
@@ -824,6 +826,16 @@
         const sel=document.getElementById('caseManagerName'); sel.innerHTML='';
         (list && list.length? list : ['（無資料）']).forEach(n=>{const o=document.createElement('option'); o.textContent=n; sel.appendChild(o);});
       }).getCaseManagersByUnit(unit);
+    }
+
+    /* ===== 照專名單 ===== */
+    function loadConsultants(){
+      const unit = document.getElementById('unitCode').value;
+      google.script.run.withSuccessHandler(list=>{
+        const sel = document.getElementById('consultName');
+        sel.innerHTML = '<option value="" class="placeholder-option" disabled selected>請選擇</option>';
+        (list && list.length ? list : ['（無資料）']).forEach(n=>{const o=document.createElement('option'); o.textContent=n; sel.appendChild(o);});
+      }).getConsultantsByUnit(unit);
     }
 
     /* ===== 三、偕同訪視者（下拉＋多筆） ===== */
@@ -1942,6 +1954,7 @@
       setDateBox('callDate', new Date());
       setDateBox('visitDate', new Date());
       loadManagers();
+      loadConsultants();
 
       // S1
       renderS1(); initSection1State();


### PR DESCRIPTION
## Summary
- Convert consultant name field to dropdown
- Load active consultants by unit from sheet and populate dropdown
- Fetch consultants on server side by unit and status
- Add placeholder option to consultant dropdown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e50569c0832bba463e0cb37dc54a