### PR TITLE
Finish outstanding requirements for PR tasks #4-#15

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -270,6 +270,14 @@
     .lesion-size-field input{ padding-right:42px; }
     .lesion-size-field .unit{ position:absolute; right:14px; top:50%; transform:translateY(-50%); color:var(--label); font-weight:600; pointer-events:none; }
     .lesion-area{ margin-top:6px; font-weight:600; color:var(--label); }
+    .action-list{ display:flex; flex-direction:column; gap:12px; }
+    .action-item{ border:1px dashed var(--border); border-radius:var(--radius); padding:14px; background:#fff; display:flex; flex-direction:column; gap:10px; }
+    .action-item-fields{ display:flex; flex-direction:column; gap:10px; }
+    .action-item textarea{ resize:vertical; min-height:96px; }
+    .action-item select{ font-size:var(--fs-ctrl); }
+    .action-item-controls{ display:flex; justify-content:flex-end; }
+    .mismatch-diff{ display:flex; flex-wrap:wrap; gap:8px; margin:8px 0; }
+    .mismatch-diff .badge{ background:var(--accent-weak); color:var(--accent); }
     .field-error{ color:#b3261e; font-size:0.95rem; margin-top:6px; display:none; }
     .field-error[data-show="1"]{ display:block; }
 
@@ -993,9 +1001,10 @@
         <div class="grid3">
           <div>
             <label>起身/移位</label>
-            <select id="s1_transfer">
+            <select id="s1_transfer" onchange="toggleAdlHow('s1_transfer')">
               <option selected>獨立</option><option>需要輕扶</option><option>中度協助</option><option>重度協助</option><option>完全依賴</option>
             </select>
+            <input id="s1_transfer_how" type="text" placeholder="請說明協助方式" style="display:none; margin-top:6px;" data-show-values="中度協助,重度協助">
           </div>
           <div>
             <label>室內行走</label>
@@ -1299,8 +1308,13 @@
         <div class="hr"></div>
 
         <!-- 補充內容 + 預覽（自動產文） -->
-        <label>建議措施（已完成之提醒／安排）</label>
-        <textarea id="s1_actions" placeholder="請輸入具體行動，例如：已提醒家屬設定白名單，避免詐騙來電。"></textarea>
+        <div class="titlebar" style="margin-top:18px;">
+          <label>建議措施（已完成之提醒／安排）</label>
+          <button type="button" class="small" onclick="addActionEntry()">＋新增</button>
+        </div>
+        <div id="s1_actions_list" class="action-list"></div>
+        <div class="hint" id="s1_actions_hint" style="display:none;">尚未新增建議措施。</div>
+        <div class="field-error" id="s1_actions_error"></div>
         <label>補充內容（選填）</label>
         <textarea id="s1_notes" placeholder="其他未涵蓋重點（限簡要）；將附加於段落末端。"></textarea>
         <textarea id="section1_out" style="display:none;"></textarea>
@@ -1358,7 +1372,19 @@
           </div>
           <div>
             <label>居住權屬</label>
-            <select id="s3_own"><option>自有</option><option>租賃</option><option>借住</option></select>
+            <select id="s3_own" onchange="toggleRentFields()"><option>自有</option><option>租賃</option><option>借住</option></select>
+          </div>
+          <div id="s3_rent_amount_wrap" style="display:none;">
+            <label>租金金額（元/月）</label>
+            <input id="s3_rent_amount" type="number" min="0" placeholder="例：12000">
+          </div>
+          <div id="s3_rent_fee_wrap" style="display:none;">
+            <label>是否含管理費</label>
+            <select id="s3_rent_fee">
+              <option value="" class="placeholder-option" disabled selected>請選擇</option>
+              <option value="含管理費">含管理費</option>
+              <option value="不含管理費">不含管理費</option>
+            </select>
           </div>
           <div>
             <label>整潔度</label>
@@ -1406,9 +1432,13 @@
 
         <div class="hr"></div>
 
+        <div class="titlebar" style="margin-top:12px;">
+          <label>主要聯繫人/決策者</label>
+          <button type="button" class="small" onclick="copyFromH1Primary()">設為主照者</button>
+        </div>
         <div class="grid2">
           <div>
-            <label>主要聯繫人/決策者</label>
+            <label>關係</label>
             <select id="sp_deciderRel">
               <option value="">—不選—</option>
               <optgroup label="配偶"><option>案妻</option><option>案夫</option></optgroup>
@@ -1421,8 +1451,12 @@
             </select>
           </div>
           <div>
-            <label>主要聯繫人/決策者（姓名）</label>
+            <label>姓名</label>
             <input id="sp_deciderName" type="text" placeholder="請選擇">
+          </div>
+          <div style="grid-column:1 / -1;">
+            <label>聯絡電話</label>
+            <input id="sp_deciderPhone" type="tel" placeholder="例如：0912-345678">
           </div>
         </div>
 
@@ -1648,6 +1682,13 @@
         <input id="rq2_service" type="text" placeholder="服務，例如：專業服務">
       </div>
       <label><input type="checkbox" id="rq2"> 2.經與<span id="rq2_who">案○</span>討論，目前因個案身體狀況，暫無<span id="rq2_service_preview" data-def="專業服務">專業服務</span>需求，日後待個案狀況好轉後，依當下狀況核定，續追蹤。</label>
+      <div id="mismatch_diff_block" style="display:none; margin-top:12px;">
+        <div class="hint" id="mismatch_diff_text">與照專建議服務不一致項目：</div>
+        <div class="mismatch-diff" id="mismatch_diff_list"></div>
+        <div class="checkcol" id="mismatch_reason_box"></div>
+        <input id="mismatch_reason_other" type="text" placeholder="請說明其他原因" style="display:none; margin-top:6px;">
+        <div class="field-error" id="mismatch_reason_error"></div>
+      </div>
     </div></div>
   </div>
 
@@ -2709,12 +2750,129 @@
       const sel=document.getElementById(id);
       const input=document.getElementById(id+'_how');
       if(!sel||!input) return;
-      const show = sel.value==='部分協助';
+      const showValues = (input.dataset.showValues || '').split(',').map(v=>v.trim()).filter(Boolean);
+      let show = false;
+      if(showValues.length){
+        show = showValues.indexOf(sel.value) !== -1;
+      }else{
+        show = sel.value==='部分協助';
+      }
       input.style.display = show? '':'none';
       if(!show){
         input.value='';
         input.classList.remove('input-invalid');
       }
+    }
+
+    let actionEntryCounter = 0;
+
+    function createActionSourceSelect(){
+      const select=document.createElement('select');
+      select.innerHTML = `
+        <option value="" class="placeholder-option" disabled selected>請選擇來源</option>
+        <option value="問題">問題</option>
+        <option value="目標">目標</option>
+        <option value="服務項目">服務項目</option>
+      `;
+      return select;
+    }
+
+    function updateActionRemoveButtons(){
+      const host=document.getElementById('s1_actions_list');
+      if(!host) return;
+      const rows=[...host.querySelectorAll('.action-item')];
+      rows.forEach(row=>{
+        const btn=row.querySelector('.action-item-controls button');
+        if(btn){ btn.style.display = rows.length>1 ? '' : 'none'; }
+      });
+    }
+
+    function updateActionHint(){
+      const hint=document.getElementById('s1_actions_hint');
+      if(!hint) return;
+      const entries=readActionEntries();
+      const hasContent = entries.some(entry=>entry.text);
+      hint.style.display = hasContent ? 'none' : '';
+    }
+
+    function addActionEntry(data){
+      const host=document.getElementById('s1_actions_list');
+      if(!host) return null;
+      const entry=data || {};
+      const row=document.createElement('div');
+      row.className='action-item';
+      row.dataset.actionId=`action-${actionEntryCounter++}`;
+
+      const fields=document.createElement('div');
+      fields.className='action-item-fields';
+      const select=createActionSourceSelect();
+      if(entry.source){ select.value=entry.source; }
+      const textarea=document.createElement('textarea');
+      textarea.placeholder='請輸入具體行動，例如：已提醒家屬設定白名單，避免詐騙來電。';
+      if(entry.text){ textarea.value=entry.text; }
+      fields.appendChild(select);
+      fields.appendChild(textarea);
+      row.appendChild(fields);
+
+      const controls=document.createElement('div');
+      controls.className='action-item-controls';
+      const removeBtn=document.createElement('button');
+      removeBtn.type='button';
+      removeBtn.className='small';
+      removeBtn.textContent='移除';
+      removeBtn.addEventListener('click', ()=>removeActionEntry(row));
+      controls.appendChild(removeBtn);
+      row.appendChild(controls);
+
+      host.appendChild(row);
+
+      select.addEventListener('change', ()=>{ select.classList.remove('input-invalid'); updateActionHint(); buildSection1(); });
+      textarea.addEventListener('input', ()=>{ textarea.classList.remove('input-invalid'); updateActionHint(); buildSection1(); });
+
+      updateActionRemoveButtons();
+      updateActionHint();
+      return row;
+    }
+
+    function removeActionEntry(row){
+      if(row) row.remove();
+      const host=document.getElementById('s1_actions_list');
+      if(host && host.childElementCount===0){
+        addActionEntry();
+      }
+      updateActionRemoveButtons();
+      updateActionHint();
+      buildSection1();
+    }
+
+    function readActionEntries(){
+      const host=document.getElementById('s1_actions_list');
+      if(!host) return [];
+      return [...host.querySelectorAll('.action-item')].map(row=>{
+        const select=row.querySelector('select');
+        const textarea=row.querySelector('textarea');
+        return {
+          row,
+          select,
+          textarea,
+          source:(select && select.value ? select.value.trim() : ''),
+          text:(textarea && textarea.value ? textarea.value.trim() : '')
+        };
+      });
+    }
+
+    function collectActionEntries(){
+      return readActionEntries()
+        .map(entry=>({source:entry.source, text:entry.text}))
+        .filter(entry=>entry.source && entry.text);
+    }
+
+    function initActionEntries(){
+      const host=document.getElementById('s1_actions_list');
+      if(!host) return;
+      if(host.childElementCount===0){ addActionEntry(); }
+      updateActionRemoveButtons();
+      updateActionHint();
     }
 
     // 病灶症狀互斥（無不適）
@@ -2746,7 +2904,10 @@
         });
       }
       const box=document.getElementById('s1_lesion_sx_box');
-      if(box) box.dataset.mode = lesionSymptomMode;
+      if(box){
+        box.dataset.mode = lesionSymptomMode;
+        box.style.display = lesionSymptomMode === 'none' ? 'none' : '';
+      }
     }
 
     function setLesionSymptomMode(mode){
@@ -2755,6 +2916,7 @@
       const box=document.getElementById('s1_lesion_sx_box');
       if(!box) return;
       box.dataset.mode = normalized;
+      box.style.display = normalized === 'none' ? 'none' : '';
       const checks=[...box.querySelectorAll('input[type=checkbox]')];
       const none=checks.find(c=>c.value==='無不適');
       const others=checks.filter(c=>c!==none);
@@ -2998,6 +3160,7 @@
 
       // 行動/ADL/排泄
       s.s1_transfer = document.getElementById('s1_transfer').value;
+      s.s1_transfer_how = document.getElementById('s1_transfer_how').value;
       s.s1_walk_indoor = document.getElementById('s1_walk_indoor').value;
       s.s1_walk_outdoor = document.getElementById('s1_walk_outdoor').value;
       s.s1_stairs = document.getElementById('s1_stairs').value;
@@ -3085,7 +3248,7 @@
       s.s1_dis_cat = disCat;     // 段一身障類別（讀取自段二）
 
       // 補充
-      s.s1_actions = document.getElementById('s1_actions').value;
+      s.s1_actions = collectActionEntries();
       s.s1_notes = document.getElementById('s1_notes').value;
 
       return s;
@@ -3218,13 +3381,30 @@
         const sx = collectChecks('s1_lesion_sx_box');
         if(!Array.isArray(sx) || !sx.length){ messages.push('請勾選至少一項病灶症狀'); markSection1Invalid('s1_lesion_sx_box'); }
 
-        const evalSel = document.getElementById('s1_lesion_eval').value;
-        if(evalSel && evalSel!=='未評估'){
-          const hosp = (document.getElementById('s1_lesion_hospital').value||'').trim();
-          if(!hosp){ messages.push('請填寫醫療院所名稱'); markSection1Invalid('s1_lesion_hospital'); }
-        }
+      const evalSel = document.getElementById('s1_lesion_eval').value;
+      if(evalSel && evalSel!=='未評估'){
+        const hosp = (document.getElementById('s1_lesion_hospital').value||'').trim();
+        if(!hosp){ messages.push('請填寫醫療院所名稱'); markSection1Invalid('s1_lesion_hospital'); }
       }
-      setFieldError('s1_lesion_size_error', lesionOn ? lesionSizeError : '');
+    }
+    setFieldError('s1_lesion_size_error', lesionOn ? lesionSizeError : '');
+
+      const actionEntries = readActionEntries();
+      let actionError='';
+      actionEntries.forEach(entry=>{
+        const hasSource = !!entry.source;
+        const hasText = !!entry.text;
+        if(hasText && !hasSource){
+          if(!actionError){ messages.push('請為建議措施選擇來源'); }
+          if(entry.select) entry.select.classList.add('input-invalid');
+          actionError = actionError || '請為建議措施選擇來源';
+        }else if(hasSource && !hasText){
+          if(!actionError){ messages.push('請填寫建議措施內容'); }
+          if(entry.textarea) entry.textarea.classList.add('input-invalid');
+          actionError = actionError || '請填寫建議措施內容';
+        }
+      });
+      setFieldError('s1_actions_error', actionError);
 
       const box=document.getElementById('section1_errors');
       if(box){
@@ -3242,7 +3422,10 @@
 
     // 產文（新版）
     function buildSection1Text_v2(s) {
-      const has = v => v !== undefined && v !== null && String(v).trim() !== "";
+      const has = v => {
+        if(Array.isArray(v)) return v.length > 0;
+        return v !== undefined && v !== null && String(v).trim() !== "";
+      };
       const join = arr => arr.filter(Boolean).join("，");
       const listCN = arr => arr.filter(Boolean).join("、");
       const sexWord = g => g === "男" ? "男性" : g === "女" ? "女性" : (g || "");
@@ -3489,7 +3672,13 @@
 
       // ④ 行動
       const moveBits=[];
-      if (has(s.s1_transfer)) moveBits.push(`起身移位${s.s1_transfer}`);
+      if (has(s.s1_transfer)) {
+        let txt=`起身移位${s.s1_transfer}`;
+        if((s.s1_transfer==='中度協助' || s.s1_transfer==='重度協助') && has(s.s1_transfer_how)){
+          txt+=`（協助方式：${s.s1_transfer_how}）`;
+        }
+        moveBits.push(txt);
+      }
       if (has(s.s1_walk_indoor)) moveBits.push(`在家${s.s1_walk_indoor}行走`);
       if (has(s.s1_walk_outdoor)) moveBits.push(`外出${s.s1_walk_outdoor}輔助`);
       if (has(s.s1_stairs)) moveBits.push(`上下樓${s.s1_stairs}`);
@@ -3647,7 +3836,18 @@
 
       // ⑨ 補充（有才輸出）
       const p9 = has(s.s1_notes) ? s.s1_notes : "";
-      const actionText = has(s.s1_actions) ? s.s1_actions : "";
+      function formatActions(actions){
+        if(Array.isArray(actions)){
+          const items = actions.filter(item=>item && has(item.source) && has(item.text));
+          if(!items.length) return "";
+          const parts = items.map(item=>`【${item.source}】${item.text}`);
+          return `建議措施：${parts.join('；')}`;
+        }
+        if(has(actions)) return String(actions);
+        return "";
+      }
+
+      const actionText = formatActions(s.s1_actions);
 
       const segments=[p1,p2,p3,p4,pSwallow,p5,p6,p7,actionText,p9].filter(Boolean);
       return `${segments.join("。")}。`;
@@ -3742,16 +3942,48 @@
       document.getElementById('s3_type_other').style.display= on?'':'none';
       buildS3();
     }
+    function toggleRentFields(){
+      const ownSelect=document.getElementById('s3_own');
+      const amountWrap=document.getElementById('s3_rent_amount_wrap');
+      const feeWrap=document.getElementById('s3_rent_fee_wrap');
+      const isRent=ownSelect && ownSelect.value==='租賃';
+      if(amountWrap) amountWrap.style.display = isRent ? '' : 'none';
+      if(feeWrap) feeWrap.style.display = isRent ? '' : 'none';
+      if(!isRent){
+        const amountInput=document.getElementById('s3_rent_amount');
+        const feeSelect=document.getElementById('s3_rent_fee');
+        if(amountInput){ amountInput.value=''; amountInput.classList.remove('input-invalid'); }
+        if(feeSelect){ feeSelect.value=''; feeSelect.classList.remove('input-invalid'); }
+      }
+      buildS3();
+    }
     function buildS3(){
       const typeSel=document.getElementById('s3_type'); let type=typeSel.value;
       if(type==='其他'){ const t=document.getElementById('s3_type_other').value.trim(); if(t) type=t; }
       const own=document.getElementById('s3_own').value;
+      const rentAmountInput=document.getElementById('s3_rent_amount');
+      const rentFeeSelect=document.getElementById('s3_rent_fee');
+      let rentInfo='';
+      if(own==='租賃'){
+        const rawAmount=(rentAmountInput?.value || '').trim();
+        const feeValue=(rentFeeSelect?.value || '').trim();
+        if(rawAmount){
+          const numeric=parseInt(rawAmount,10);
+          const formatted=!Number.isNaN(numeric) && numeric>=0 ? numeric.toLocaleString('zh-TW') : rawAmount;
+          rentInfo = `月租${formatted}元`;
+          if(feeValue){ rentInfo += `（${feeValue}）`; }
+        }else if(feeValue){
+          rentInfo = feeValue;
+        }
+      }
       const clean=document.getElementById('s3_clean').value;
       const smell=document.getElementById('s3_smell').value;
       const fac=[...document.querySelectorAll('#s3_fac input[type=checkbox]')].filter(x=>x.checked).map(x=>x.value);
       const aids=[...document.querySelectorAll('#s3_aids input[type=checkbox]')].filter(x=>x.checked).map(x=>x.value);
       if(!type) { document.getElementById('section3_out').value=''; return; }
-      let s=`現居住於${own}${type}，環境整潔度${clean}，${smell==='無'?'無異味':(smell+'異味')}。`;
+      let base=`現居住於${own}${type}`;
+      if(rentInfo){ base += `，${rentInfo}`; }
+      let s=`${base}，環境整潔度${clean}，${smell==='無'?'無異味':(smell+'異味')}。`;
       if(fac.length) s+=`無障礙設施：${fac.join('、')}。`;
       if(aids.length) s+=`已備輔具：${aids.join('、')}。`;
       document.getElementById('section3_out').value=s;
@@ -4234,6 +4466,7 @@
     function renderFormal(){
       const host=document.getElementById('sp_formal');
       host.innerHTML='';
+      ba02WeeklyDisplays = {};
       FORMAL.forEach((name)=>{
         const lab=document.createElement('label');
         lab.innerHTML=`<input type="checkbox" value="${name}" onchange="toggleGoalInputs()"> ${name}`;
@@ -4462,6 +4695,19 @@
 
 
     const servicePlanState = {};
+    let ba02WeeklyDisplays = {};
+    const MISMATCH_REASON_OPTIONS = [
+      { value:'身體狀況', label:'身體狀況變化', short:'身體狀況' },
+      { value:'個案意願', label:'個案意願', short:'個案意願' },
+      { value:'資源限制', label:'資源或額度限制', short:'資源限制' },
+      { value:'經濟考量', label:'經濟考量', short:'經濟考量' },
+      { value:'其他', label:'其他（請說明）', short:'其他' }
+    ];
+    const MISMATCH_CATEGORY_KEYS = new Set(['居家服務','日間照顧','專業服務','交通接送','喘息服務','無障礙及輔具','營養送餐']);
+    const MISMATCH_REASON_LOOKUP = {};
+    MISMATCH_REASON_OPTIONS.forEach(opt=>{ MISMATCH_REASON_LOOKUP[opt.value] = opt; });
+    let mismatchReasonInitialized = false;
+    let currentMismatchDiff = [];
     const planMetaState = {
       referralExtra: '',
       stationInfo: '',
@@ -4543,6 +4789,210 @@
       return servicePlanState[code];
     }
 
+    function renderMismatchReasonOptions(){
+      if(mismatchReasonInitialized) return;
+      const host=document.getElementById('mismatch_reason_box');
+      if(!host) return;
+      host.innerHTML='';
+      MISMATCH_REASON_OPTIONS.forEach(option=>{
+        const label=document.createElement('label');
+        const input=document.createElement('input');
+        input.type='checkbox';
+        input.value=option.value;
+        input.dataset.mismatchReason='1';
+        label.appendChild(input);
+        label.appendChild(document.createTextNode(' '+option.label));
+        host.appendChild(label);
+      });
+      mismatchReasonInitialized = true;
+    }
+
+    function getSelectedMismatchReasons(){
+      return [...document.querySelectorAll('#mismatch_reason_box input[type=checkbox]:checked')]
+        .map(input=>input.value);
+    }
+
+    function mapEntryToMismatchCategory(entry){
+      if(!entry) return '';
+      const code=(entry.code || '').trim();
+      if(!code) return '';
+      if(code.startsWith('BB')) return '日間照顧';
+      if(code === 'BD03' || code.startsWith('DA')) return '交通接送';
+      const first=code.charAt(0);
+      if(first === 'B') return '居家服務';
+      if(first === 'C') return '專業服務';
+      if(first === 'D') return '交通接送';
+      if(first === 'G') return '喘息服務';
+      if(first === 'E' || first === 'F') return '無障礙及輔具';
+      if(code.startsWith('OT')) return '營養送餐';
+      return '';
+    }
+
+    function computeMismatchDifferences(){
+      const recommended=[...document.querySelectorAll('#sp_formal input[type=checkbox]:checked')]
+        .map(input=>input.value)
+        .filter(value=>MISMATCH_CATEGORY_KEYS.has(value));
+      if(!recommended.length) return [];
+      const provided=new Set();
+      Object.values(servicePlanState).forEach(entry=>{
+        const cat=mapEntryToMismatchCategory(entry);
+        if(cat && MISMATCH_CATEGORY_KEYS.has(cat)){
+          provided.add(cat);
+        }
+      });
+      const diff=[];
+      recommended.forEach(cat=>{
+        if(!provided.has(cat)) diff.push(cat);
+      });
+      return diff;
+    }
+
+    function setMismatchError(message){
+      const box=document.getElementById('mismatch_reason_error');
+      if(!box) return;
+      if(message){
+        box.textContent=message;
+        box.dataset.show='1';
+        box.style.display='';
+      }else{
+        box.textContent='';
+        box.dataset.show='0';
+        box.style.display='none';
+      }
+    }
+
+    function updateMismatchReasonOtherVisibility(){
+      const other=document.getElementById('mismatch_reason_other');
+      if(!other) return;
+      const selected=getSelectedMismatchReasons();
+      const show=selected.includes('其他');
+      other.style.display = show ? '' : 'none';
+      if(!show){
+        other.value='';
+        other.classList.remove('input-invalid');
+      }
+    }
+
+    function validateMismatchReasons(){
+      const diff=currentMismatchDiff || [];
+      const other=document.getElementById('mismatch_reason_other');
+      const inputs=[...document.querySelectorAll('#mismatch_reason_box input[type=checkbox]')];
+      inputs.forEach(input=>input.classList.remove('input-invalid'));
+      if(other) other.classList.remove('input-invalid');
+      if(!diff.length){
+        setMismatchError('');
+        return true;
+      }
+      const selected=getSelectedMismatchReasons();
+      if(!selected.length){
+        setMismatchError('請勾選不一致原因');
+        inputs.forEach(input=>input.classList.add('input-invalid'));
+        return false;
+      }
+      if(selected.includes('其他')){
+        const text=(other?.value || '').trim();
+        if(!text){
+          setMismatchError('請填寫其他原因說明');
+          if(other){
+            other.classList.add('input-invalid');
+            other.focus();
+          }
+          return false;
+        }
+      }
+      setMismatchError('');
+      return true;
+    }
+
+    function updateMismatchReasons(opts){
+      opts = opts || {};
+      const diff=computeMismatchDifferences();
+      currentMismatchDiff = diff;
+      const block=document.getElementById('mismatch_diff_block');
+      const list=document.getElementById('mismatch_diff_list');
+      const hint=document.getElementById('mismatch_diff_text');
+      if(diff.length){
+        if(block) block.style.display='';
+        if(hint) hint.textContent=`與照專建議服務不一致項目：${diff.join('、')}`;
+        if(list){
+          list.innerHTML='';
+          diff.forEach(name=>{
+            const badge=document.createElement('span');
+            badge.className='badge';
+            badge.textContent=name;
+            list.appendChild(badge);
+          });
+        }
+      }else{
+        if(block) block.style.display='none';
+        if(list) list.innerHTML='';
+        setMismatchError('');
+      }
+      updateMismatchReasonOtherVisibility();
+      if(diff.length){
+        validateMismatchReasons();
+      }
+      if(!opts.skipPreview){
+        buildApprovalPlanPreview();
+      }
+    }
+
+    function onMismatchReasonChange(evt){
+      const target=evt && evt.target ? evt.target : null;
+      if(target && target.type === 'checkbox'){
+        target.classList.remove('input-invalid');
+      }
+      setMismatchError('');
+      updateMismatchReasonOtherVisibility();
+      updateMismatchReasons();
+    }
+
+    function initMismatchReasonControls(){
+      renderMismatchReasonOptions();
+      const box=document.getElementById('mismatch_reason_box');
+      if(box){
+        box.addEventListener('change', onMismatchReasonChange);
+      }
+      const other=document.getElementById('mismatch_reason_other');
+      if(other){
+        other.addEventListener('input', ()=>{
+          other.classList.remove('input-invalid');
+          setMismatchError('');
+          buildApprovalPlanPreview();
+        });
+      }
+      updateMismatchReasonOtherVisibility();
+      updateMismatchReasons({skipPreview:true});
+    }
+
+    function getMismatchReasonSummary(){
+      if(!currentMismatchDiff || !currentMismatchDiff.length) return '';
+      const selected=getSelectedMismatchReasons();
+      if(!selected.length) return '';
+      const names=[];
+      selected.forEach(value=>{
+        const option=MISMATCH_REASON_LOOKUP[value];
+        if(value === '其他'){
+          const other=(document.getElementById('mismatch_reason_other')?.value || '').trim();
+          if(other){
+            names.push(other);
+          }
+        }else if(option && option.short){
+          names.push(option.short);
+        }else{
+          names.push(value);
+        }
+      });
+      const unique=[];
+      names.forEach(name=>{
+        if(name && unique.indexOf(name) === -1){
+          unique.push(name);
+        }
+      });
+      if(!unique.length) return '';
+      return `不一致原因：${unique.join('、')}`;
+    }
+
     function removePlanEntry(code){
       if(servicePlanState[code]) delete servicePlanState[code];
     }
@@ -4573,6 +5023,7 @@
       });
       applyAutomaticPlanning();
       renderServicePlanEditor();
+      updateMismatchReasons({skipPreview:true});
       buildPlanSummaryPreview();
       buildApprovalPlanPreview();
     }
@@ -4852,6 +5303,9 @@
           updatePlanMonthlyComputation(code);
           skipPreview=true;
         }
+        if(code === 'BA02'){
+          updateBa02WeeklyDisplay(code);
+        }
       }else if(field === 'frequency'){
         if((entry[field]||'').trim()){
           entry.frequencyManual = true;
@@ -5063,9 +5517,11 @@
         if(entry.mealsPerDay) lines.push(`每日${entry.mealsPerDay}餐`);
         if(entry.mealType) lines.push(entry.mealType);
       }else{
-        const monthly = entry.monthlyUnits || entry.monthlyUnitsComputed;
-        if(monthly) lines.push(`${monthly} 單位/月`);
-        if(entry.monthlyExtraDesc) lines.push(entry.monthlyExtraDesc);
+        if(category !== 'C'){
+          const monthly = entry.monthlyUnits || entry.monthlyUnitsComputed;
+          if(monthly) lines.push(`${monthly} 單位/月`);
+          if(entry.monthlyExtraDesc) lines.push(entry.monthlyExtraDesc);
+        }
       }
       if(!lines.length && entry.planned) lines.push(entry.planned);
       return lines.join('\n');
@@ -5074,9 +5530,14 @@
     function formatSummaryUsage(entry){
       if(!entry) return '';
       const lines = [];
+      const category = (entry.category || determineServiceCategory(entry.code) || '').toUpperCase();
       if(entry.period) lines.push(`期間：${entry.period}`);
       const freq = entry.frequencyManual ? entry.frequency : (entry.autoFrequencyText || entry.frequency);
-      if(freq) lines.push(freq);
+      if(freq && category !== 'C') lines.push(freq);
+      if(entry.code === 'BA02'){
+        const weeklyText=buildBa02WeeklyText(entry);
+        if(weeklyText) lines.push(weeklyText);
+      }
       if(entry.usage){
         lines.push(entry.usage);
       }else if(entry.autoUsageText){
@@ -5355,6 +5816,27 @@
               appendAutoSummaryField(grid, entry, '預估交通安排');
               const usageField=createPlanInput(entry,'usage','交通使用方式',{as:'textarea',placeholder:'系統已提供建議內容，可再補充乘車安排',className:'full'});
               grid.appendChild(usageField.wrap);
+            }else if(entry.code === 'BA02'){
+              const vendorField=createPlanInput(entry,'vendorMode','供應模式',{as:'select',options:[{value:'輪派',label:'輪派'},{value:'指定',label:'指定'}]});
+              grid.appendChild(vendorField.wrap);
+              const vendorNameField=createPlanInput(entry,'vendorName','指定單位',{placeholder:'例：○○○服務單位'});
+              vendorNameField.wrap.dataset.planVendorName=entry.code;
+              grid.appendChild(vendorNameField.wrap);
+              const unitField=createPlanInput(entry,'monthlyUnits','月目標',{placeholder:'例：10',attrs:{inputmode:'decimal'}});
+              grid.appendChild(unitField.wrap);
+              const weeklyWrap=document.createElement('div');
+              weeklyWrap.className='plan-field';
+              const weeklyLabel=document.createElement('label');
+              weeklyLabel.textContent='換算每週次數';
+              weeklyWrap.appendChild(weeklyLabel);
+              const weeklyBox=document.createElement('div');
+              weeklyBox.className='auto-summary-box empty';
+              weeklyBox.dataset.planBa02Display = entry.code;
+              weeklyWrap.appendChild(weeklyBox);
+              grid.appendChild(weeklyWrap);
+              ba02WeeklyDisplays[entry.code] = weeklyBox;
+              const usageField=createPlanInput(entry,'usage','使用方式或案主期待',{as:'textarea',placeholder:'請描述服務內容、案主期待或家屬配合情況'});
+              grid.appendChild(usageField.wrap);
             }else{
               const vendorField=createPlanInput(entry,'vendorMode','供應模式',{as:'select',options:[{value:'輪派',label:'輪派'},{value:'指定',label:'指定'}]});
               grid.appendChild(vendorField.wrap);
@@ -5408,11 +5890,9 @@
             const vendorNameField=createPlanInput(entry,'vendorName','指定單位',{placeholder:'例：○○○專業服務單位'});
             vendorNameField.wrap.dataset.planVendorName=entry.code;
             grid.appendChild(vendorNameField.wrap);
-            const unitField=createPlanInput(entry,'monthlyUnits','月單位（如適用）',{placeholder:'例：8',attrs:{inputmode:'decimal'}});
-            grid.appendChild(unitField.wrap);
-            const freqField=createPlanInput(entry,'frequency','服務頻率／方式',{placeholder:'例：每月2次專業評估與指導'});
-            grid.appendChild(freqField.wrap);
-            const usageField=createPlanInput(entry,'usage','案主期待或配合狀況',{as:'textarea',placeholder:'請描述欲改善之ADL/IADL項目、家屬配合情況'});
+            const periodField=createPlanInput(entry,'period','服務期間',{placeholder:'例：113年01月至113年03月'});
+            grid.appendChild(periodField.wrap);
+            const usageField=createPlanInput(entry,'usage','單次規劃說明',{as:'textarea',placeholder:'請描述專業服務內容與案主/家屬配合情況'});
             grid.appendChild(usageField.wrap);
           }else if(cat==='EF'){
             const periodField=createPlanInput(entry,'period','補助額度期間',{placeholder:'例：113年01月~113年12月'});
@@ -5452,13 +5932,34 @@
           }
           entryBox.appendChild(grid);
           section.appendChild(entryBox);
+          if(entry.code === 'BA02'){
+            updateBa02WeeklyDisplay(entry.code);
+          }
           updatePlanVendorVisibility(entry.code);
-          if(!(entry.code && entry.code.indexOf('BB') === 0) && entry.code !== 'BD03'){
+          if(!(entry.code && entry.code.indexOf('BB') === 0) && entry.code !== 'BD03' && entry.code !== 'BA02'){
             updatePlanMonthlyComputation(entry.code, {skipPreview:true});
           }
         });
         host.appendChild(section);
       });
+    }
+
+    function updateBa02WeeklyDisplay(code){
+      if(!code) return;
+      const box=ba02WeeklyDisplays[code];
+      if(!box || !box.isConnected){
+        if(ba02WeeklyDisplays[code]) delete ba02WeeklyDisplays[code];
+        return;
+      }
+      const entry=servicePlanState[code];
+      const text=buildBa02WeeklyText(entry);
+      if(text){
+        box.textContent=text;
+        box.classList.remove('empty');
+      }else{
+        box.textContent='尚未設定月目標';
+        box.classList.add('empty');
+      }
     }
 
     function appendAutoSummaryField(grid, entry, label){
@@ -5502,11 +6003,9 @@
       if(!(monthlyValue > 0)) return '';
       const weeklyValue=Math.ceil(monthlyValue / 4.5);
       if(!(weeklyValue > 0)) return '';
-      const monthlyText=formatPlanNumber(monthlyValue);
       const weeklyText=formatPlanNumber(weeklyValue);
-      if(!monthlyText || !weeklyText) return '';
-      const weeksText=formatPlanNumber(4.5) || '4.5';
-      return `由月目標 ${monthlyText} 次換算，每月 ${weeksText} 週 → 每週 ${weeklyText} 次`;
+      if(!weeklyText) return '';
+      return `每週 ${weeklyText} 次`;
     }
 
     function formatPlanEntryB(entry, idx){
@@ -5562,16 +6061,21 @@
       }else if(entry.vendorMode){
         vendor = `（${entry.vendorMode}）`;
       }
-      const monthly = entry.monthlyUnits ? `*${entry.monthlyUnits}` : '*（請填月單位）';
+      const period=(entry.period || '').trim();
+      const usageText=(entry.usage || entry.autoUsageText || '').trim();
       const parts=[];
-      if(entry.frequency) parts.push(entry.frequency);
-      if(entry.usage){
-        parts.push(entry.usage);
+      if(period) parts.push(`期間：${period}`);
+      if(usageText){
+        parts.push(usageText);
       }else{
-        parts.push('請補充案主最希望改善之ADL/IADL項目及配合情況');
+        parts.push('請補充單次規劃說明');
       }
-      let text=`${idx}.${entry.code}[${entry.name || ''}]${monthly}${vendor}`;
-      text += `：${parts.join('；')}`;
+      let text=`${idx}.${entry.code}[${entry.name || ''}]${vendor}`;
+      if(parts.length){
+        text += `：${parts.join('；')}`;
+      }else{
+        text += '：請補充單次規劃說明。';
+      }
       if(!text.endsWith('。')) text += '。';
       return text;
     }
@@ -5753,6 +6257,10 @@
       const problemTexts=getSelectedProblemTexts();
       if(problemTexts.length){
         lines.push(`（服務對應問題：${problemTexts.join('、')}）`);
+      }
+      const mismatchSummary=getMismatchReasonSummary();
+      if(mismatchSummary){
+        lines.push(mismatchSummary);
       }
       lines.push('告知與同意：');
       lines.push(`上述計畫，均告知${formatCaseDisplay()}其了解計畫內容並同意服務使用，並簽訂服務使用確認單。（請單位留存確認單備查）`);
@@ -6181,13 +6689,34 @@
     }
 
     function copyFromH1Primary(){
-      let rel=document.getElementById('primaryRel').value;
-      let name=(document.getElementById('primaryName').value||'').trim();
+      const relSelect=document.getElementById('primaryRel');
+      const nameInput=document.getElementById('primaryName');
       const caseName=(document.getElementById('caseName').value||'').trim();
+      let rel=relSelect ? relSelect.value : '';
+      let name=nameInput ? nameInput.value.trim() : '';
       if(!rel){ rel='本人'; if(!name) name=caseName; }
       if(!name){ alert('三、偕同訪視者的主要照顧者尚未完整。'); return; }
-      document.getElementById('sp_primaryRel').value= rel==='自訂角色'?'自訂角色':rel;
-      document.getElementById('sp_primaryName').value= name;
+      const sourcePhone = (document.getElementById('primaryPhone')?.value
+        || document.getElementById('primaryTel')?.value
+        || document.getElementById('primaryContactPhone')?.value || '').trim();
+      const deciderRel=document.getElementById('sp_deciderRel');
+      const deciderName=document.getElementById('sp_deciderName');
+      const deciderPhone=document.getElementById('sp_deciderPhone');
+      if(deciderRel){
+        const optionExists=[...deciderRel.options].some(opt=>opt.value===rel);
+        deciderRel.value = optionExists ? rel : '';
+        deciderRel.dispatchEvent(new Event('change', {bubbles:true}));
+      }
+      if(deciderName){
+        deciderName.value = name;
+        deciderName.dispatchEvent(new Event('input', {bubbles:true}));
+      }
+      if(deciderPhone){
+        deciderPhone.value = sourcePhone;
+        deciderPhone.dispatchEvent(new Event('input', {bubbles:true}));
+      }
+      syncQuickWho();
+      buildSection4();
     }
     function addCoCare(){
       const host=document.getElementById('coCare');
@@ -6565,6 +7094,12 @@
         return;
       }
 
+      if(!validateMismatchReasons()){
+        msg.textContent='請完成與照專建議服務不一致原因說明。';
+        document.getElementById('mismatch_diff_block')?.scrollIntoView({behavior:'smooth', block:'center'});
+        return;
+      }
+
       // 組裝各段
       buildSection1(section1Validation);
       buildS2(); buildS3(); buildSection4(); buildSection6(); buildLongGoal();
@@ -6656,6 +7191,7 @@
       renderHearingDetails();
       applyLocationStateToUI();
       updateLocationVisibility();
+      toggleAdlHow('s1_transfer');
       toggleAdlHow('s1_adl_eating'); toggleAdlHow('s1_adl_groom'); toggleAdlHow('s1_adl_bathing');
       toggleAdlHow('s1_adl_dressing'); toggleAdlHow('s1_post_toilet'); toggleAdlHow('s1_meal_prep');
       toggleAdlHow('s1_housework'); toggleAdlHow('s1_finance');
@@ -6670,6 +7206,8 @@
         s1block.addEventListener('input', buildSection1);
         s1block.addEventListener('change', buildSection1);
       }
+
+      initActionEntries();
 
       buildSection1(); // 初次預覽一次
     }
@@ -6699,7 +7237,7 @@
 
       // 其它原有初始化
       renderS2(); syncDisab();
-      renderS3(); toggleOtherType(); buildS3();
+      renderS3(); toggleOtherType(); toggleRentFields();
       const goalFields=['short_care','short_prof','short_car','short_resp','short_access','short_meal','mid_care','mid_prof','mid_car','mid_resp','mid_access','mid_meal'];
       goalFields.forEach(id=>{
         bindAutoGoalField(id);
@@ -6716,6 +7254,7 @@
       renderRespiteServices();
       renderMealServices();
       initPlanMetaFields();
+      initMismatchReasonControls();
       planMetaState.referralExtra = document.getElementById('plan_referral_extra')?.value || '';
       planMetaState.stationInfo = document.getElementById('plan_station_info')?.value || '';
       planMetaState.stationWillingness = document.getElementById('plan_station_willingness')?.value || '';


### PR DESCRIPTION
## Summary
- Hide the lesion symptom checklist when selecting 「無不適」 and show a supplemental transfer detail input for higher assistance levels, keeping the preview text in sync.
- Replace the 建議措施 textarea with a source-tagged action list (complete with validation and preview formatting) and add rent-specific fields and a copy-from-primary button in the居住/聯繫人 sections.
- Update the service plan editor so BA02 auto-derives a weekly frequency from the monthly target, C碼 only captures period and single-use notes, and mismatched formal-service categories now require documented reasons that flow into the approval preview.

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ce499db624832bbe4d6ae4d3ed7fa1