### PR TITLE
Simplify date controls and enhance validation feedback

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -145,8 +145,12 @@
       flex-wrap:wrap;
       align-items:center;
     }
-    .date-controls button.small{ min-width:64px; }
-    .date-controls button.calendar-btn{ min-width:72px; }
+    .date-controls button.small{
+      min-width:48px;
+      font-size:22px;
+      font-weight:700;
+      line-height:1;
+    }
 
     /* 按鈕與操作面積（主按鈕 56px，小按鈕 48px） */
     .btnbar{ display:flex; gap:12px; flex-wrap:wrap; margin-top:10px; }
@@ -722,7 +726,7 @@
     #errorSummary{
       display:none;
       margin-top:12px;
-      padding:12px 16px;
+      padding:16px;
       border:1px solid #fca5a5;
       border-radius:var(--radius);
       background:#fff5f5;
@@ -730,9 +734,83 @@
       font-size:.95rem;
     }
     #errorSummary[data-show="1"]{ display:block; }
+    #errorSummary .error-panel-title{
+      font-weight:700;
+      margin-bottom:8px;
+    }
+    #errorSummary .error-panel-section{
+      padding-top:12px;
+      margin-top:12px;
+      border-top:1px solid rgba(185,38,38,.2);
+    }
+    #errorSummary .error-panel-section:first-of-type{
+      border-top:none;
+      padding-top:0;
+      margin-top:0;
+    }
+    #errorSummary .error-panel-section-title{
+      font-weight:700;
+      font-size:1rem;
+      margin-bottom:6px;
+    }
     #errorSummary ul{ margin:0; padding-left:20px; }
     #errorSummary li{ margin-bottom:6px; }
-    #errorSummary a{ color:#b3261e; text-decoration:underline; cursor:pointer; }
+    #errorSummary a{
+      color:#b3261e;
+      text-decoration:underline;
+      cursor:pointer;
+      font-weight:600;
+    }
+    #validationToast{
+      position:fixed;
+      right:24px;
+      bottom:calc(24px + env(safe-area-inset-bottom));
+      max-width:360px;
+      width:calc(100% - 48px);
+      background:#111827;
+      color:#fff;
+      padding:16px;
+      border-radius:16px;
+      box-shadow:0 18px 40px rgba(15,23,42,.25);
+      display:flex;
+      flex-direction:column;
+      gap:12px;
+      opacity:0;
+      transform:translateY(12px);
+      pointer-events:none;
+      transition:opacity .25s ease, transform .25s ease;
+      z-index:999;
+      box-sizing:border-box;
+    }
+    #validationToast[data-show="1"]{
+      opacity:1;
+      transform:translateY(0);
+      pointer-events:auto;
+    }
+    #validationToast .toast-title{
+      font-weight:700;
+      font-size:1rem;
+    }
+    #validationToast .toast-message{
+      font-size:.95rem;
+      line-height:1.5;
+    }
+    #validationToast .toast-actions{
+      display:flex;
+      gap:8px;
+      flex-wrap:wrap;
+    }
+    #validationToast button.small{
+      height:var(--h-button-sm);
+    }
+    @media (max-width:600px){
+      #validationToast{
+        left:12px;
+        right:12px;
+        width:auto;
+        bottom:calc(12px + env(safe-area-inset-bottom));
+      }
+    }
     .input-invalid{
       border-color:#d92d20 !important;
       box-shadow:0 0 0 2px rgba(217,45,32,.2) !important;
@@ -835,11 +913,8 @@
     <div id="callDateControls" class="datebox">
       <input id="callDate" type="date">
       <div class="date-controls">
-        <button type="button" class="small" onclick="shiftDate('callDate', -5)">-5天</button>
-        <button type="button" class="small" onclick="shiftDate('callDate',  5)">+5天</button>
-        <button type="button" class="small" onclick="shiftDate('callDate', -1)">-1天</button>
-        <button type="button" class="small" onclick="shiftDate('callDate',  1)">+1天</button>
-        <button type="button" class="small calendar-btn" onclick="openDatePicker('callDate')">日曆</button>
+        <button type="button" class="small" aria-label="前一天" onclick="shiftDate('callDate', -1)">−</button>
+        <button type="button" class="small" aria-label="後一天" onclick="shiftDate('callDate',  1)">+</button>
       </div>
     </div>
     <div class="row" style="margin-top:8px;">
@@ -856,11 +931,8 @@
     <div class="datebox">
       <input id="visitDate" type="date">
       <div class="date-controls">
-        <button type="button" class="small" onclick="shiftDate('visitDate', -5)">-5天</button>
-        <button type="button" class="small" onclick="shiftDate('visitDate',  5)">+5天</button>
-        <button type="button" class="small" onclick="shiftDate('visitDate', -1)">-1天</button>
-        <button type="button" class="small" onclick="shiftDate('visitDate',  1)">+1天</button>
-        <button type="button" class="small calendar-btn" onclick="openDatePicker('visitDate')">日曆</button>
+        <button type="button" class="small" aria-label="前一天" onclick="shiftDate('visitDate', -1)">−</button>
+        <button type="button" class="small" aria-label="後一天" onclick="shiftDate('visitDate',  1)">+</button>
       </div>
     </div>
     <div class="row" style="margin-top:8px;">
@@ -872,11 +944,8 @@
       <div class="datebox">
         <input id="dischargeDate" type="date">
         <div class="date-controls">
-          <button type="button" class="small" onclick="shiftDate('dischargeDate', -5)">-5天</button>
-          <button type="button" class="small" onclick="shiftDate('dischargeDate',  5)">+5天</button>
-          <button type="button" class="small" onclick="shiftDate('dischargeDate', -1)">-1天</button>
-          <button type="button" class="small" onclick="shiftDate('dischargeDate',  1)">+1天</button>
-          <button type="button" class="small calendar-btn" onclick="openDatePicker('dischargeDate')">日曆</button>
+          <button type="button" class="small" aria-label="前一天" onclick="shiftDate('dischargeDate', -1)">−</button>
+          <button type="button" class="small" aria-label="後一天" onclick="shiftDate('dischargeDate',  1)">+</button>
         </div>
       </div>
     </div>
@@ -1939,6 +2008,15 @@
   </div>
   </div>
 
+  <div id="validationToast" data-show="0" role="alert" aria-live="assertive">
+    <div class="toast-title">提交前請先修正</div>
+    <div class="toast-message" id="validationToastText">表單有未完成的欄位，請補齊後再提交。</div>
+    <div class="toast-actions">
+      <button type="button" class="small primary" id="validationToastAction">前往修正</button>
+      <button type="button" class="small" id="validationToastClose">稍後再看</button>
+    </div>
+  </div>
+
   <script>
     /* ===== 日期工具 ===== */
     function toYMD(d){const y=d.getFullYear(),m=('0'+(d.getMonth()+1)).slice(-2),da=('0'+d.getDate()).slice(-2);return `${y}-${m}-${da}`;}
@@ -1972,25 +2050,14 @@
     function attachDateInputEvents(id){
       const input=document.getElementById(id);
       if(!input) return;
-      input.setAttribute('title','↑/↓ ±1 天，Shift+↑/↓ ±5 天');
+      input.setAttribute('title','↑/↓ 調整 ±1 天');
       input.addEventListener('keydown', ev=>{
         if(ev.key==='ArrowUp' || ev.key==='ArrowDown'){
-          const step = ev.shiftKey ? 5 : 1;
-          const delta = ev.key==='ArrowUp' ? step : -step;
+          const delta = ev.key==='ArrowUp' ? 1 : -1;
           shiftDate(id, delta);
           ev.preventDefault();
         }
       });
-    }
-    function openDatePicker(id){
-      const input=document.getElementById(id);
-      if(!input) return;
-      if(typeof input.showPicker === 'function'){
-        input.showPicker();
-      }else{
-        input.focus();
-        input.click();
-      }
     }
     function initDateInputs(){
       ['callDate','visitDate','dischargeDate'].forEach(attachDateInputEvents);
@@ -8452,6 +8519,75 @@
       return { ok: messages.length===0, messages };
     }
 
+    function normalizeLabelText(text){
+      return text ? text.replace(/\s+/g, ' ').trim() : '';
+    }
+
+    function getErrorSectionLabelFromField(field){
+      if(!field) return '';
+      if(field.closest){
+        const sectionBlock = field.closest('[data-section]');
+        if(sectionBlock){
+          const headerLabel = normalizeLabelText(sectionBlock.querySelector('.titlebar label')?.textContent);
+          if(headerLabel) return headerLabel;
+        }
+        const sectionGroup = field.closest('.section-group');
+        if(sectionGroup){
+          const toggleLabel = normalizeLabelText(sectionGroup.querySelector('.section-group-toggle')?.textContent);
+          if(toggleLabel) return toggleLabel;
+          const innerTitle = normalizeLabelText(sectionGroup.querySelector('.titlebar label')?.textContent);
+          if(innerTitle) return innerTitle;
+        }
+      }
+      let node = field;
+      while(node){
+        if(node.classList && node.classList.contains('group')){
+          for(let i=0; i<node.children.length; i++){
+            const child=node.children[i];
+            if(child && child.tagName && child.tagName.toLowerCase()==='label'){
+              const label=normalizeLabelText(child.textContent);
+              if(label) return label;
+            }
+          }
+        }
+        node = node.parentElement;
+      }
+      return '';
+    }
+
+    function resolveErrorSectionLabel(msg){
+      if(!msg) return '其他';
+      if(msg.section){
+        const labeled = normalizeLabelText(msg.section);
+        if(labeled) return labeled;
+      }
+      if(msg.fieldId){
+        const field=document.getElementById(msg.fieldId);
+        const label=getErrorSectionLabelFromField(field);
+        if(label) return label;
+      }
+      if(msg.pageId){
+        const tab=document.querySelector(`.page-tabs button[data-page="${msg.pageId}"]`);
+        const tabLabel=normalizeLabelText(tab?.textContent);
+        if(tabLabel) return tabLabel;
+      }
+      return '其他';
+    }
+
+    function groupErrorsBySection(messages){
+      const ordered=[];
+      const map=new Map();
+      (messages || []).forEach(msg=>{
+        const sectionLabel=resolveErrorSectionLabel(msg);
+        if(!map.has(sectionLabel)){
+          map.set(sectionLabel, { label: sectionLabel, items: [] });
+          ordered.push(map.get(sectionLabel));
+        }
+        map.get(sectionLabel).items.push(msg);
+      });
+      return ordered;
+    }
+
     function renderErrorSummary(messages){
       const box=document.getElementById('errorSummary');
       if(!box) return;
@@ -8460,19 +8596,64 @@
         box.dataset.show='0';
         return;
       }
-      const listItems=messages.map(msg=>{
-        const fieldId=msg && msg.fieldId ? msg.fieldId : '';
-        const pageId=msg && msg.pageId ? msg.pageId : '';
-        const text=msg && msg.text ? msg.text : '';
-        const safeText=escapeHtml(text);
-        const attrs=`data-target="${escapeHtml(fieldId)}" data-page="${escapeHtml(pageId)}"`;
-        return `<li><a href="#" ${attrs}>${safeText}</a></li>`;
+      const grouped = groupErrorsBySection(messages);
+      const sectionsHtml = grouped.map(group=>{
+        const sectionTitle = escapeHtml(group.label || '其他');
+        const itemsHtml = (group.items || []).map(msg=>{
+          const fieldId = msg && msg.fieldId ? msg.fieldId : '';
+          const pageId = msg && msg.pageId ? msg.pageId : '';
+          const text = msg && msg.text ? msg.text : '';
+          const safeText = escapeHtml(text);
+          const attrs = `data-target="${escapeHtml(fieldId)}" data-page="${escapeHtml(pageId)}"`;
+          return `<li><a href="#" ${attrs}>${safeText}</a></li>`;
+        }).join('');
+        return `<div class="error-panel-section"><div class="error-panel-section-title">${sectionTitle}</div><ul>${itemsHtml}</ul></div>`;
       }).join('');
-      box.innerHTML = `<div>請修正以下欄位：</div><ul>${listItems}</ul>`;
+      box.innerHTML = `<div class="error-panel-title">請修正以下欄位：</div>${sectionsHtml}`;
       box.dataset.show='1';
       box.querySelectorAll('a').forEach(link=>{
         link.addEventListener('click', handleErrorSummaryClick);
       });
+    }
+
+    function showValidationToast(sectionLabel, firstError){
+      const toast=document.getElementById('validationToast');
+      const textEl=document.getElementById('validationToastText');
+      if(!toast || !textEl) return;
+      const normalized=normalizeLabelText(sectionLabel);
+      const label = normalized && normalized !== '其他' ? normalized : '表單';
+      textEl.textContent = `${label} 有未完成的欄位，請補齊後再提交。`;
+      toast.dataset.show='1';
+      toast.dataset.target = firstError && firstError.fieldId ? firstError.fieldId : '';
+      toast.dataset.page = firstError && firstError.pageId ? firstError.pageId : '';
+    }
+
+    function hideValidationToast(){
+      const toast=document.getElementById('validationToast');
+      if(!toast) return;
+      toast.dataset.show='0';
+      toast.dataset.target='';
+      toast.dataset.page='';
+    }
+
+    function initValidationToast(){
+      const toast=document.getElementById('validationToast');
+      if(!toast) return;
+      hideValidationToast();
+      const action=document.getElementById('validationToastAction');
+      if(action){
+        action.addEventListener('click', ()=>{
+          const pageId=toast.dataset.page;
+          const targetId=toast.dataset.target;
+          hideValidationToast();
+          if(pageId) setActivePage(pageId);
+          focusErrorTarget(targetId);
+        });
+      }
+      const close=document.getElementById('validationToastClose');
+      if(close){
+        close.addEventListener('click', ()=>hideValidationToast());
+      }
     }
 
     function handleErrorSummaryClick(evt){
@@ -8481,6 +8662,7 @@
       if(!link) return;
       const pageId=link.dataset.page;
       const fieldId=link.dataset.target;
+      hideValidationToast();
       if(pageId) setActivePage(pageId);
       focusErrorTarget(fieldId);
     }
@@ -8510,6 +8692,7 @@
     function applyAndSave(){
       const msg=document.getElementById('msg');
       if(msg) msg.textContent='';
+      hideValidationToast();
       renderErrorSummary([]);
       const unitCode=document.getElementById('unitCode').value;
       const caseManagerName=document.getElementById('caseManagerName').value;
@@ -8553,6 +8736,8 @@
         if(first){
           if(first.pageId) setActivePage(first.pageId);
           focusErrorTarget(first.fieldId);
+          const sectionLabel=resolveErrorSectionLabel(first);
+          showValidationToast(sectionLabel, first);
         }
         return;
       }
@@ -8675,6 +8860,7 @@
 
     window.addEventListener('load', ()=>{
       initPageTabs();
+      initValidationToast();
       initDateInputs();
       setDateBox('callDate', new Date());
       setDateBox('visitDate', new Date());


### PR DESCRIPTION
## Summary
- Reduce each date control to ±1 day steppers and update their styling and keyboard hints for consistency.
- Group validation errors by section, keep links scrollable, and surface a toast with a quick jump to the first blocking issue.

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ce9c8accec832bb3f20ecca9a94c4a