### PR TITLE
Improve staff lookup caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ AA01 可以透過兩種模式使用：綁定 Google 文件的側欄（原始設�
 
 3. **後端寫入** (`AppCore.gs`)
    - `applyAndSave` 先計算新檔名稱（`FNA1_YYYYMMDD_個案姓名_個管師姓名_V{版號}`），並以「個案×個管師」為唯一鍵遞增版號。
+   - 個管師與照專名單在伺服端以 Script Cache 暫存 30 分鐘，避免頻繁讀取 Google 試算表造成延遲。
    - 於 `OUTPUT_FOLDER_ID` 指定的資料夾中，以 `TEMPLATE_DOC_ID` 為模板建立副本並開啟 Body。
    - `DOCUMENT_WRITERS` 依序呼叫 `applyH1_*` 函式處理各段落（邏輯集中於 `AppCore.gs`）：
     - `applyH1_CallDate` / `applyH1_VisitDate`：更新標題列文字或插入出院日期。


### PR DESCRIPTION
## Summary
- cache case manager and consultant lookups to avoid repeated spreadsheet scans on each request
- document the new caching behaviour in the README

## Testing
- not run (Apps Script environment)


------
https://chatgpt.com/codex/tasks/task_e_68d0ca654d98832bbec2f61b33e166d6