### PR TITLE
Fix sticky header spacer causing blank viewport gap

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -208,7 +208,9 @@
     .app-container{
       width:100%;
       margin:0 auto;
-      padding-top:var(--app-top-offset);
+      padding-top:var(--space-xs);
+      padding-top:calc(var(--space-xs) + constant(safe-area-inset-top));
+      padding-top:calc(var(--space-xs) + env(safe-area-inset-top));
       padding-bottom:calc(var(--fab-h, 0px) + var(--space-md));
       box-sizing:border-box;
     }


### PR DESCRIPTION
## Summary
- cap the app container's top padding to a small safe-area aware value so the sticky header no longer leaves a large empty gap when scrolling to the top

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d14c2e4aac832badadc0fa9543c06e