### PR TITLE
Fix sticky overflow panel collapse on sidebar

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -491,9 +491,12 @@
       flex-wrap:wrap;
     }
     #stickyOverflowPanel{
-      display:flex;
+      display:none;
       flex-direction:column;
       gap:var(--space-sm);
+    }
+    .app-sticky[data-expanded="1"] #stickyOverflowPanel{
+      display:flex;
     }
     .sticky-overflow-toggle{
       display:inline-flex;
@@ -533,8 +536,6 @@
       .app-sticky[data-expanded="1"] .sticky-row--tabs{ display:flex; }
     }
     @media (max-width:1279px){
-      #stickyOverflowPanel{ display:none; }
-      .app-sticky[data-expanded="1"] #stickyOverflowPanel{ display:flex; }
       .sticky-row--wizard{ align-items:center; }
     }
     @media (max-width:720px){


### PR DESCRIPTION
## Summary
- hide the sticky summary/overflow panel by default so the collapsed state no longer blocks the form
- only show the overflow panel when expanded and keep the mobile override lean

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d15d2dd664832bb6e15c88713f8e63