### PR TITLE
Align heading writers with updated template hierarchy

### DIFF
--- a/DataStore.gs
+++ b/DataStore.gs
@@ -39,13 +39,44 @@ const H1_TEMPLATES = Object.freeze({
   })
 });
 
+const BASIC_INFO_SECTIONS = Object.freeze([
+  { key: 'unitCode', headings: ['單位代碼：', '單位代碼:', '單位代碼'] },
+  { key: 'caseManagerName', headings: ['個案管理師：', '個案管理師:', '個案管理師'] },
+  { key: 'caseName', headings: ['個案姓名：', '個案姓名:', '個案姓名'] },
+  {
+    key: 'consultName',
+    headings: ['照專姓名：', '照專姓名:', '照專姓名', '照顧專員姓名：', '照顧專員姓名:', '照顧專員姓名']
+  },
+  { key: 'cmsLevel', headings: ['CMS 等級：', 'CMS 等級:', 'CMS 等級'] }
+]);
+
 const H1_CASE_PROFILE_SECTIONS = Object.freeze([
-  { key: 'section1', headings: ['(一)身心概況：','(一) 身心概況：','（一）身心概況：'] },
-  { key: 'section2', headings: ['(二)經濟收入：','(二) 經濟收入：','（二）經濟收入：'] },
-  { key: 'section3', headings: ['(三)居住環境：','(三) 居住環境：','（三）居住環境：'] },
-  { key: 'section4', headings: ['(四)社會支持：','(四) 社會支持：','（四）社會支持：'] },
-  { key: 'section5', headings: ['(五)其他：','(五) 其他：','（五）其他：'], fallback: '無。' },
-  { key: 'section6', headings: ['(六)複評評值：','(六) 複評評值：','（六）複評評值：'], fallback: '此個案為新案，無複評評值。' }
+  {
+    key: 'section1',
+    headings: ['(一)身心概況：', '(一) 身心概況：', '（一）身心概況：', '(一)身心概況', '(一) 身心概況', '（一）身心概況']
+  },
+  {
+    key: 'section2',
+    headings: ['(二)經濟收入：', '(二) 經濟收入：', '（二）經濟收入：', '(二)經濟收入', '(二) 經濟收入', '（二）經濟收入']
+  },
+  {
+    key: 'section3',
+    headings: ['(三)居住環境：', '(三) 居住環境：', '（三）居住環境：', '(三)居住環境', '(三) 居住環境', '（三）居住環境']
+  },
+  {
+    key: 'section4',
+    headings: ['(四)社會支持：', '(四) 社會支持：', '（四）社會支持：', '(四)社會支持', '(四) 社會支持', '（四）社會支持']
+  },
+  {
+    key: 'section5',
+    headings: ['(五)其他：', '(五) 其他：', '（五）其他：', '(五)其他', '(五) 其他', '（五）其他'],
+    fallback: '無。'
+  },
+  {
+    key: 'section6',
+    headings: ['(六)複評評值：', '(六) 複評評值：', '（六）複評評值：', '(六)複評評值', '(六) 複評評值', '（六）複評評值'],
+    fallback: '此個案為新案，無複評評值。'
+  }
 ]);
 
 const H1_PROBLEM_DICT = Object.freeze({
@@ -60,7 +91,7 @@ const H1_PROBLEM_DICT = Object.freeze({
 
 const H1_PROBLEM_HEADING_VARIANTS = (function(){
   const bases = ['(一)照顧問題','(一) 照顧問題','（一）照顧問題','（一） 照顧問題'];
-  const marks = ['：', ':'];
+  const marks = ['：', ':', ''];
   const prefixes = ['', '五、照顧目標', '五、照顧目標 ', '五、 照顧目標', '五、 照顧目標 '];
   const joiners = ['', '：', ':', '： ', ': ', ' '];
   const variants = [];
@@ -92,16 +123,30 @@ const H1_GOAL_CATEGORY_FIELDS = Object.freeze([
 ]);
 
 const H1_GOAL_TIERS = Object.freeze([
-  { prefix: 'short', headings: ['(二)短期目標','(二) 短期目標'] },
-  { prefix: 'mid', headings: ['(三)中期目標','(三) 中期目標'] }
+  {
+    prefix: 'short',
+    headings: ['(二)短期目標', '(二) 短期目標', '（二）短期目標', '(二)短期目標(0-3個月)', '(二) 短期目標(0-3個月)', '（二）短期目標(0-3個月)', '（二）短期目標（0-3個月）']
+  },
+  {
+    prefix: 'mid',
+    headings: ['(三)中期目標', '(三) 中期目標', '（三）中期目標', '(三)中期目標(3-4個月)', '(三) 中期目標(3-4個月)', '（三）中期目標(3-4個月)', '（三）中期目標（3-4個月）']
+  }
 ]);
 
-const H1_LONG_GOAL_HEADINGS = Object.freeze(['(四)長期目標','(四) 長期目標']);
+const H1_LONG_GOAL_HEADINGS = Object.freeze([
+  '(四)長期目標',
+  '(四) 長期目標',
+  '（四）長期目標',
+  '(四)長期目標(4-6個月)',
+  '(四) 長期目標(4-6個月)',
+  '（四）長期目標(4-6個月)',
+  '（四）長期目標（4-6個月）'
+]);
 
 const H1_MISMATCH_REASON_FIELDS = Object.freeze([
-  { key: 'reason1', prefix: '1.目標達成的狀況以及未達成的差距：' },
-  { key: 'reason2', prefix: '2.資源的變動情形：' },
-  { key: 'reason3', prefix: '3.未使用的替代方案或是可能的影響：' }
+  { key: 'reason1', prefix: '（一）目標達成的狀況以及未達成的差距：' },
+  { key: 'reason2', prefix: '（二）資源的變動情形：' },
+  { key: 'reason3', prefix: '（三）未使用的替代方案或是可能的影響：' }
 ]);
 
 const H1_MISMATCH_QUICK_TEMPLATES = Object.freeze({

--- a/README.md
+++ b/README.md
@@ -120,10 +120,11 @@ AA01 可以透過兩種模式使用：綁定 Google 文件的側欄（原始設�
    - `applyAndSave` 先計算新檔名稱（`FNA1_YYYYMMDD_個案姓名_個管師姓名_V{版號}`），並以「個案×個管師」為唯一鍵遞增版號。
    - 於 `OUTPUT_FOLDER_ID` 指定的資料夾中，以 `TEMPLATE_DOC_ID` 為模板建立副本並開啟 Body。
    - `DOCUMENT_WRITERS` 依序呼叫 `applyH1_*` 函式處理各段落（邏輯集中於 `AppCore.gs`）：
-    - `applyH1_CallDate` / `applyH1_VisitDate`：更新標題列文字或插入出院日期。
-    - `applyH1_Attendees`：組出偕同訪視者句子（包含主照者、照專、其他參與者）。
+    - `applyBasicInfoSection`：寫入「基本資訊」分頁的 H2 欄位（單位代碼、個案管理師、個案姓名、照專姓名、CMS 等級），支援冒號同行與段落分行兩種模板。
+    - `applyH1_CallDate` / `applyH1_VisitDate`：同時支援舊版冒號格式與新版 H2/H3 層級，分別填入電聯日期、家訪日期與出院日期欄位。
+    - `applyH1_Attendees`：除保留舊版摘要句外，也會更新「主要照顧者／其他參與者」的關係、姓名 H3 欄位。
     - `applyH1_CaseProfile`：依新版層級輸出「四、個案概況」，（一）身心概況細分為基本資料、感官功能、吞嚥與飲食、口腔／牙齒、疼痛與皮膚、移動功能、排泄與輔具、ADL、IADL、情緒與行為、醫療與用藥、睡眠與日間活動、管路／裝置、身障資訊、建議措施與補充；後續保留（二）經濟收入、（三）居住環境、（四）社會支持、（五）其他、（六）複評評值（含結構化預覽），必要時補上預設文字並同步更新唯讀欄位。
-    - `applyH1_CareGoals`：寫入照顧問題、短/中期四格、長期目標。
+    - `applyH1_CareGoals`：寫入照顧問題、短/中期四格、長期目標（含 0–3/3–4/4–6 個月標示）。
     - `applyH1_MismatchPlan`：整合不一致原因與常用快捷語句。
    - 接著透過 `applyPlanExecutionPage` 與 `applyPlanServiceSummaryPage` 在文件結尾加入頁 2（計畫執行規劃）與頁 3（服務明細），自動插入分頁。
    - 完成後儲存關閉文件，回傳新檔資訊給前端。


### PR DESCRIPTION
## Summary
- add a Basic Info writer and adjust call/visit handlers to populate the new H2/H3 headings while keeping backward compatibility with the colon-based template
- rewrite attendee output to fill the individual caregiver/participant headings and expand heading detection helpers to respect additional labels
- extend DataStore heading dictionaries with the new labels and timelines, and document the server updates in the README

## Testing
- not run (GAS environment)


------
https://chatgpt.com/codex/tasks/task_e_68d19901f8a0832bb0f98b937b0bc04a