### PR TITLE
Fix page tab activation fallback

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -14522,7 +14522,7 @@
         if(label) return label;
       }
       if(msg.pageId){
-        const tab=document.querySelector(`.page-tabs button[data-page="${msg.pageId}"]`);
+        const tab=document.querySelector(`.page-tabs [data-page="${msg.pageId}"]`);
         const tabLabel=normalizeLabelText(tab?.textContent);
         if(tabLabel) return tabLabel;
       }
@@ -15051,13 +15051,13 @@
     }
 
     function syncTabStatuses(){
-      const tabs=document.querySelectorAll('.page-tabs button');
+      const tabs=document.querySelectorAll('.page-tabs [data-page]');
       if(!tabs.length){
         return;
       }
       if(!wizardStepsMeta.length){
         tabs.forEach(btn=>{
-          const isActive=btn.classList.contains('active');
+          const isActive=btn.classList ? btn.classList.contains('active') : false;
           btn.dataset.status = isActive ? 'active' : 'todo';
         });
         return;
@@ -15082,7 +15082,7 @@
         if(assigned){
           btn.dataset.status = assigned;
         }else{
-          const isActive=btn.classList.contains('active');
+          const isActive=btn.classList ? btn.classList.contains('active') : false;
           btn.dataset.status = isActive ? 'active' : 'todo';
         }
       });
@@ -15329,28 +15329,66 @@
 
 
         /* ===== 初始化 ===== */
+    function handlePageTabClick(event){
+      const el = event ? (event.currentTarget || event.target) : null;
+      if(!el) return;
+      const btn = el.closest ? el.closest('[data-page]') : el;
+      const pageId = btn && btn.dataset ? btn.dataset.page : '';
+      setActivePage(pageId);
+    }
+
     function setActivePage(pageId, options){
-      if(!pageId) return false;
+      const sections = Array.from(document.querySelectorAll('.page-section'));
+      if(!sections.length) return false;
+      const requestedId = typeof pageId === 'string' ? pageId : (pageId ? String(pageId) : '');
       const opts = options || {};
-      const targetStep = determineWizardStepForPage(pageId, opts);
+      const targetStep = requestedId ? determineWizardStepForPage(requestedId, opts) : null;
       if(targetStep !== null && isWizardStepLocked(targetStep)){
         handleWizardStepLocked(targetStep);
         return false;
       }
-      currentPageId = pageId;
-      const sections=document.querySelectorAll('.page-section');
+      let activeSection = null;
+      if(requestedId){
+        for(let i=0;i<sections.length;i++){
+          const section = sections[i];
+          if(section && section.dataset && section.dataset.page === requestedId){
+            activeSection = section;
+            break;
+          }
+        }
+      }
+      if(!activeSection){
+        activeSection = sections[0] || null;
+      }
+      if(!activeSection) return false;
+      const finalPageId = activeSection.dataset ? (activeSection.dataset.page || '') : '';
       sections.forEach(section=>{
-        const active = section.dataset.page === pageId ? '1' : '0';
-        section.dataset.active = active;
-        section.style.display = active === '1' ? '' : 'none';
+        if(!section) return;
+        const isActive = section === activeSection;
+        section.dataset.active = isActive ? '1' : '0';
+        section.style.display = isActive ? '' : 'none';
       });
-      document.querySelectorAll('.page-tabs button').forEach(btn=>{
-        const isActive = btn.dataset.page === pageId;
-        btn.classList.toggle('active', isActive);
-        btn.setAttribute('aria-current', isActive ? 'page' : 'false');
+      currentPageId = finalPageId;
+      document.querySelectorAll('.page-tabs [data-page]').forEach(btn=>{
+        const btnPage = btn && btn.dataset ? btn.dataset.page : '';
+        const isActive = btnPage === finalPageId;
+        if(btn.classList){
+          btn.classList.toggle('active', isActive);
+        }
+        if(typeof btn.setAttribute === 'function'){
+          btn.setAttribute('aria-current', isActive ? 'page' : 'false');
+        }
       });
-      if(targetStep !== null){
-        updateWizardVisual(targetStep);
+      let effectiveStep = null;
+      if(finalPageId){
+        if(finalPageId === requestedId){
+          effectiveStep = targetStep;
+        }else{
+          effectiveStep = determineWizardStepForPage(finalPageId, {});
+        }
+      }
+      if(effectiveStep !== null){
+        updateWizardVisual(effectiveStep);
       }else{
         updateWizardButtons();
         syncTabStatuses();
@@ -15362,14 +15400,17 @@
     }
 
     function initPageTabs(){
-      const tabs=[...document.querySelectorAll('.page-tabs button')];
+      const tabs=[...document.querySelectorAll('.page-tabs [data-page]')];
       if(!tabs.length) return;
       tabs.forEach(btn=>{
-        btn.addEventListener('click', ()=>setActivePage(btn.dataset.page));
+        btn.addEventListener('click', handlePageTabClick);
       });
-      const initial = tabs.find(btn=>btn.classList.contains('active')) || tabs[0];
+      const initial = tabs.find(btn=>btn.classList && btn.classList.contains('active')) || tabs[0];
       if(initial){
-        setActivePage(initial.dataset.page);
+        const initialPageId = initial.dataset ? initial.dataset.page : '';
+        setActivePage(initialPageId || '');
+      }else{
+        setActivePage('');
       }
     }
 


### PR DESCRIPTION
## Summary
- add a defensive page tab click handler that resolves the closest `[data-page]` target before switching sections
- harden `setActivePage` to keep at least one section visible and resync wizard/tabs even when the requested page id is missing
- update tab initialization and status lookups to reuse the safe selector and avoid `classList` issues

## Testing
- not run (Google Apps Script IDE required)


------
https://chatgpt.com/codex/tasks/task_e_68d25922c5e4832b9892d2f47d12eb73