### PR TITLE
Fix goal page expansion when unlocking plan group

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -15475,7 +15475,24 @@
         groupElement.dataset.planLocked = planGroupState.locked ? '1' : '0';
       }
       const ctrl=simpleGroupControllers['contactVisitGroup'];
+      const shouldExpand = planGroupState.pendingExpand || (options && options.expand);
       if(!ctrl || !ctrl.element){
+        if(groupElement){
+          if(planGroupState.locked){
+            if(groupElement.dataset.collapsed !== '1'){
+              groupElement.dataset.collapsed = '1';
+              scheduleStickyMeasurement();
+              scheduleLayoutMeasurements();
+            }
+          }else if(shouldExpand){
+            if(groupElement.dataset.collapsed !== '0'){
+              groupElement.dataset.collapsed = '0';
+              scheduleStickyMeasurement();
+              scheduleLayoutMeasurements();
+            }
+            planGroupState.pendingExpand = false;
+          }
+        }
         return;
       }
       const toggle=ctrl.toggle || ctrl.element.querySelector('.group-collapse');
@@ -15493,7 +15510,7 @@
         if(ctrl.element.dataset.collapsed !== '1'){
           ctrl.applyState(true);
         }
-      }else if(planGroupState.pendingExpand || (options && options.expand)){
+      }else if(shouldExpand){
         ctrl.applyState(false);
         planGroupState.pendingExpand = false;
       }


### PR DESCRIPTION
## Summary
- ensure the goals page group updates its collapsed state even when no collapsible controller is registered
- keep pending-expand state in sync and trigger layout recalculation so the goals content becomes visible after completing basic info

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d25efd678c832b8a6430299490db36