### PR TITLE
Ensure dedupe runs before sidebar initialization

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -16156,11 +16156,12 @@
       });
     }
 
-    window.addEventListener('load', ()=>{
+    function initializeSidebarOnLoad(){
+      // 先排除重複的 page-section 與全域 ID，避免後續初始化操作到錯誤節點
+      dedupeGoalsSection();
       if(google && google.script && google.script.host && typeof google.script.host.setWidth === 'function'){
         try{ google.script.host.setWidth(900); }catch(err){}
       }
-      dedupeGoalsSection();
       initUiPresetControls();
       initFontScaleControls();
       initWizardFlow();
@@ -16295,7 +16296,9 @@
 
       scheduleLayoutMeasurements();
 
-    });
+    }
+
+    window.addEventListener('load', initializeSidebarOnLoad);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap the sidebar load routine in a named function so dedupeGoalsSection executes first
- keep the rest of the initialization sequence intact after deduplication

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2bfd0be4c832bbe2efcf9c2c9b3ff