### PR TITLE
Ensure heading spec validation initializes toast

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -17242,15 +17242,15 @@
       prepareCaseProfileLayout();
       renderServicePlanEditor();
       applyHeadingSpecToDom();
+      const headingSpecReport = logHeadingSpecReport();
+      handleHeadingSpecValidation(headingSpecReport);
+      initHeadingSpecToast();
       ensureAllGroupBodies(document);
       initGroupCollapsibles();
-      initHeadingSpecToast();
       initSectionViews();
       refreshExecutionHeadingRegistry();
       applyHeadingSpecVersionUpgrade();
       ensureGoalsPageDefaults();
-      const headingSpecReport = logHeadingSpecReport();
-      handleHeadingSpecValidation(headingSpecReport);
       scheduleSummaryUpdate();
       scheduleAllMeasurements();
       if(google && google.script && google.script.host && typeof google.script.host.setWidth === 'function'){


### PR DESCRIPTION
## Summary
- log the heading spec report and surface validation results immediately after applying the spec during sidebar initialization
- initialize the heading spec toast right after validation so the remediation controls are always bound on load

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d390135b00832bb8b75b89f8477013