### PR TITLE
Refactor sidebar section layout

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -1124,37 +1124,37 @@
     #contactVisitGroup .plan-card-mismatch{
       grid-column:1 / -1;
     }
-    #visitPartnersGroup{
+    #visitPartnersCard{
       position:relative;
     }
-    #visitPartnersGroup .extra-row{
+    #visitPartnersCard .extra-row{
       display:flex;
       flex-wrap:wrap;
       gap:var(--gap);
       align-items:flex-start;
       margin-top:var(--space-xs);
     }
-    #visitPartnersGroup .extra-row .field-intro{
+    #visitPartnersCard .extra-row .field-intro{
       flex:0 0 var(--intro-colw);
       max-width:var(--intro-colw);
     }
     @media (max-width:720px){
-      #visitPartnersGroup .extra-row{
+      #visitPartnersCard .extra-row{
         flex-direction:column;
         align-items:stretch;
       }
-      #visitPartnersGroup .extra-row .field-intro{
+      #visitPartnersCard .extra-row .field-intro{
         flex:1 1 100%;
         max-width:100%;
       }
     }
-    #visitPartnersGroup .extra-row-actions{
+    #visitPartnersCard .extra-row-actions{
       display:flex;
       align-items:center;
       justify-content:center;
       flex:0 0 auto;
     }
-    #visitPartnersGroup .extra-remove{
+    #visitPartnersCard .extra-remove{
       width:42px;
       height:42px;
       border-radius:999px;
@@ -1169,14 +1169,14 @@
       color:#4b5563;
       transition:background .15s ease, border-color .15s ease, color .15s ease;
     }
-    #visitPartnersGroup .extra-remove:hover,
-    #visitPartnersGroup .extra-remove:focus{
+    #visitPartnersCard .extra-remove:hover,
+    #visitPartnersCard .extra-remove:focus{
       background:rgba(11,87,208,.12);
       border-color:var(--accent);
       color:var(--accent);
       outline:none;
     }
-    #visitPartnersGroup .extra-remove span{ pointer-events:none; }
+    #visitPartnersCard .extra-remove span{ pointer-events:none; }
     #extras_conflict{
       position:absolute;
       top:var(--group-padding);
@@ -1194,7 +1194,7 @@
       z-index:2;
     }
     #extras_conflict[data-show="1"]{ display:block; }
-    #visitPartnersGroup[data-conflict="1"]{
+    #visitPartnersCard[data-conflict="1"]{
       background:linear-gradient(0deg, rgba(254,249,195,.55), rgba(254,249,195,.55)), var(--card);
       border-color:#facc15;
     }
@@ -2768,7 +2768,7 @@
             <span class="wizard-index">2</span>
             <span class="wizard-label">計畫目標</span>
           </button>
-          <button type="button" class="wizard-step" data-step="3" data-page="execution" data-anchor="#planExecutionGroup">
+          <button type="button" class="wizard-step" data-step="3" data-page="execution" data-anchor="#planExecutionCard">
             <span class="wizard-index">3</span>
             <span class="wizard-label">計畫執行規劃</span>
           </button>
@@ -2881,63 +2881,64 @@
       </div>
       <div class="group-content">
         <div class="section-card-grid">
-        <section class="section-card" id="basicInfoSection">
-          <div class="titlebar">
-            <span class="h2">基本資訊</span>
-          </div>
-          <div class="basic-info-fields">
-            <div class="basic-info-row" data-row="1">
-              <div class="basic-info-field unit-code-field field-intro" data-field-size="short">
-                <label class="h3" for="unitCode">單位代碼</label>
-                <select id="unitCode" onchange="loadManagers(); loadConsultants();">
-                  <option>FNA1</option><option>FNA2</option><option>FNA3</option>
-                </select>
+          <section class="section-card" id="basicInfoSection">
+            <div class="titlebar">
+              <span class="h2">基本資訊</span>
+            </div>
+            <div class="basic-info-fields">
+              <div class="basic-info-row" data-row="1">
+                <div class="basic-info-field unit-code-field field-intro" data-field-size="short">
+                  <label class="h3" for="unitCode">單位代碼</label>
+                  <select id="unitCode" onchange="loadManagers(); loadConsultants();">
+                    <option>FNA1</option><option>FNA2</option><option>FNA3</option>
+                  </select>
+                </div>
+                <div class="basic-info-field case-manager-field field-intro" data-field-size="medium" data-basic-required="1">
+                  <label class="h3" for="caseManagerName">個案管理師</label>
+                  <select id="caseManagerName">
+                    <option value="" class="placeholder-option" disabled selected>請選擇</option>
+                  </select>
+                  <div class="basic-info-status" id="caseManagerStatus" role="status" aria-live="polite"></div>
+                </div>
               </div>
-              <div class="basic-info-field case-manager-field field-intro" data-field-size="medium" data-basic-required="1">
-                <label class="h3" for="caseManagerName">個案管理師</label>
-                <select id="caseManagerName">
-                  <option value="" class="placeholder-option" disabled selected>請選擇</option>
-                </select>
-                <div class="basic-info-status" id="caseManagerStatus" role="status" aria-live="polite"></div>
+              <div class="basic-info-row" data-row="2">
+                <div class="basic-info-field case-name-field field-intro" data-field-size="medium" data-basic-required="1">
+                  <label class="h3" for="caseName">個案姓名</label>
+                  <input id="caseName" type="text" placeholder="請輸入">
+                  <div class="basic-info-status" id="caseNameStatus" role="status" aria-live="polite"></div>
+                </div>
+                <div class="basic-info-field consult-name-field field-intro" data-field-size="medium" data-basic-required="1">
+                  <label class="h3" for="consultName">照專姓名</label>
+                  <select id="consultName">
+                    <option value="" class="placeholder-option" disabled selected>請選擇</option>
+                  </select>
+                  <div class="basic-info-status" id="consultStatus" role="status" aria-live="polite"></div>
+                </div>
+              </div>
+              <div class="cms-level-row" data-row="3" data-basic-required="1">
+                <label class="h3" for="cmsLevelValue">CMS 等級</label>
+                <div id="cmsLevelGroup" class="cms-level-group">
+                  <button type="button" data-level="2">2</button>
+                  <button type="button" data-level="3">3</button>
+                  <button type="button" data-level="4">4</button>
+                  <button type="button" data-level="5">5</button>
+                  <button type="button" data-level="6">6</button>
+                  <button type="button" data-level="7">7</button>
+                  <button type="button" data-level="8">8</button>
+                </div>
+                <div class="hint cms-level-hint">選擇 CMS 等級後會同步填入隱藏欄位。</div>
+                <div class="basic-info-status" id="cmsLevelStatus" role="status" aria-live="polite"></div>
+                <input type="hidden" id="cmsLevelValue" value="">
               </div>
             </div>
-            <div class="basic-info-row" data-row="2">
-              <div class="basic-info-field case-name-field field-intro" data-field-size="medium" data-basic-required="1">
-                <label class="h3" for="caseName">個案姓名</label>
-                <input id="caseName" type="text" placeholder="請輸入">
-                <div class="basic-info-status" id="caseNameStatus" role="status" aria-live="polite"></div>
-              </div>
-              <div class="basic-info-field consult-name-field field-intro" data-field-size="medium" data-basic-required="1">
-                <label class="h3" for="consultName">照專姓名</label>
-                <select id="consultName">
-                  <option value="" class="placeholder-option" disabled selected>請選擇</option>
-                </select>
-                <div class="basic-info-status" id="consultStatus" role="status" aria-live="polite"></div>
-              </div>
-            </div>
-            <div class="cms-level-row" data-row="3" data-basic-required="1">
-              <label class="h3" for="cmsLevelValue">CMS 等級</label>
-              <div id="cmsLevelGroup" class="cms-level-group">
-                <button type="button" data-level="2">2</button>
-                <button type="button" data-level="3">3</button>
-                <button type="button" data-level="4">4</button>
-                <button type="button" data-level="5">5</button>
-                <button type="button" data-level="6">6</button>
-                <button type="button" data-level="7">7</button>
-                <button type="button" data-level="8">8</button>
-              </div>
-              <div class="hint cms-level-hint">選擇 CMS 等級後會同步填入隱藏欄位。</div>
-              <div class="basic-info-status" id="cmsLevelStatus" role="status" aria-live="polite"></div>
-              <input type="hidden" id="cmsLevelValue" value="">
-            </div>
-          </div>
-        </section>
+          </section>
+        </div>
       </div>
     </div>
   </div>
 
   <div class="page-section" data-page="goals" data-active="0" data-columns="2">
-    <section class="group card-main" id="contactVisitGroup" data-collapsed="0" data-plan-locked="0">
+    <div class="group card-main" id="contactVisitGroup" data-collapsed="0" data-plan-locked="0">
       <div class="group-header">
         <div class="titlebar">
           <span class="h1">計畫目標</span>
@@ -2982,7 +2983,7 @@
               </div>
             </section>
 
-            <section class="section-card contact-visit-card" id="visitPartnersGroup" data-card="partners">
+            <section class="section-card contact-visit-card" id="visitPartnersCard" data-card="partners">
               <div class="titlebar contact-visit-card-header">
                 <span class="h2">三、偕同訪視者</span>
               </div>
@@ -3015,1186 +3016,1190 @@
                 <div id="extras_conflict" role="status" aria-live="polite"></div>
               </div>
             </section>
+          </div>
+        </div>
+      </div>
 
-            <!-- 四、個案概況 -->
-            <section class="group plan-card-case-overview" id="caseOverviewGroup" data-span="full" data-collapsed="0">
-              <div class="group-header">
-                <div class="titlebar">
-                  <span class="h2 heading-tier heading-tier--primary">四、個案概況</span>
-                  <span class="hint" style="margin:0;">系統已即時檢查必填欄位，缺漏將以紅框提示。</span>
-                </div>
+        <!-- 四、個案概況 -->
+        <div class="group plan-card-case-overview" id="caseOverviewGroup" data-span="full" data-collapsed="0">
+          <div class="group-header">
+            <div class="titlebar">
+              <span class="h2 heading-tier heading-tier--primary">四、個案概況</span>
+              <span class="hint" style="margin:0;">系統已即時檢查必填欄位，缺漏將以紅框提示。</span>
+            </div>
+          </div>
+
+          <div class="group-content">
+            <div id="section1_block" data-section="s1">
+              <div class="titlebar">
+                <label class="h3 heading-tier heading-tier--primary">（一）身心概況</label>
               </div>
+              <!-- (一) 身心概況：已更新 + 連動 + 自動產文 -->
+              <div id="section1_error_summary" class="error-summary" data-group-ignore="1" data-show="0" aria-live="polite"></div>
 
-              <div class="group-content">
-                <div id="section1_block" data-section="s1">
-                  <div class="titlebar">
-                    <label class="h3 heading-tier heading-tier--primary">（一）身心概況</label>
+                <div class="section-card-grid" id="caseProfileBasicGroup">
+                  <section class="section-card" id="caseProfileBasicCard">
+                    <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="short">
+                            <label class="h3" for="s1_age">年齡</label>
+                            <input id="s1_age" type="number" min="1" max="120" value="70">
+                          </div>
+                          <div class="field" data-field-size="short">
+                            <label class="h3" for="s1_gender">性別</label>
+                            <select id="s1_gender">
+                              <option>男</option>
+                              <option>女</option>
+                            </select>
+                          </div>
+                          <div class="field" data-field-size="long">
+                            <label class="h3">溝通語言／方式</label>
+                            <div class="checkcol" id="s1_lang_box"></div>
+                            <input id="s1_lang_note" type="text" placeholder="備註（例如：以台語為主）" style="margin-top:var(--space-xs);">
+                          </div>
+                    </div>
+                  </section>
+                </div>
+
+                <div class="group" id="caseProfileSensoryGroup" data-collapsed="0">
+                  <div class="group-header">
+                    <span class="h3 heading-tier heading-tier--section">感官功能</span>
                   </div>
-                  <!-- (一) 身心概況：已更新 + 連動 + 自動產文 -->
-                  <div id="section1_error_summary" class="error-summary" data-group-ignore="1" data-show="0" aria-live="polite"></div>
-
-                    <div class="section-card-grid" id="caseProfileBasicGroup">
-                      <section class="section-card" id="caseProfileBasicCard">
+                  <div class="group-content">
+                    <div class="section-card-grid">
+                      <section class="section-card" id="caseProfileVisionCard">
+                        <span class="h5 heading-tier heading-tier--subsection">視力</span>
                         <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="short">
-                                <label class="h3" for="s1_age">年齡</label>
-                                <input id="s1_age" type="number" min="1" max="120" value="70">
-                              </div>
-                              <div class="field" data-field-size="short">
-                                <label class="h3" for="s1_gender">性別</label>
-                                <select id="s1_gender">
-                                  <option>男</option>
-                                  <option>女</option>
-                                </select>
-                              </div>
-                              <div class="field" data-field-size="long">
-                                <label class="h3">溝通語言／方式</label>
-                                <div class="checkcol" id="s1_lang_box"></div>
-                                <input id="s1_lang_note" type="text" placeholder="備註（例如：以台語為主）" style="margin-top:var(--space-xs);">
-                              </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_vision">視力程度</label>
+                            <select id="s1_vision" onchange="toggleVisionNotes()">
+                              <option>視力清晰</option>
+                              <option>靠近才能辨識</option>
+                              <option>即使配戴眼鏡，仍難以辨識</option>
+                              <option>僅能分辨明暗，無法辨識人臉或物體輪廓</option>
+                              <option>完全失去視覺功能，無法感知光線</option>
+                            </select>
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3">視力補充說明【選填】</label>
+                            <div class="checkcol" id="s1_vision_note_box"></div>
+                            <input id="s1_vision_other" type="text" placeholder="其他說明" style="display:none; margin-top:var(--space-xs);">
+                            <div id="s1_glasses_adherence_wrap" style="display:none; margin-top:var(--space-xs);">
+                              <label class="h4" for="s1_glasses_adherence">配戴情形</label>
+                              <select id="s1_glasses_adherence">
+                                <option value="" class="placeholder-option" disabled selected>配戴情形</option>
+                                <option>常態配戴</option>
+                                <option>偶爾配戴</option>
+                                <option>不配戴</option>
+                              </select>
+                            </div>
+                            <div id="s1_vision_auto_hint" class="hint auto-hint" style="display:none; margin-top:var(--space-xs);">
+                              <span>已依視力狀態預選建議補充（標記為「系統預選」）。</span>
+                              <button type="button" class="small" onclick="resetVisionSuggestions()">還原為預設</button>
+                            </div>
+                          </div>
+                        </div>
+                      </section>
+                      <section class="section-card" id="caseProfileHearingCard">
+                        <span class="h5 heading-tier heading-tier--subsection">聽力</span>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_hearing_level">聽力程度</label>
+                            <select id="s1_hearing_level" onchange="renderHearingDetails()">
+                              <option>無明顯異常</option>
+                              <option>輕度受損</option>
+                              <option>中度受損</option>
+                              <option>重度受損</option>
+                              <option>極重度受損</option>
+                              <option>完全失聰</option>
+                            </select>
+                          </div>
+                          <div class="field" id="s1_hearing_detail_wrap" data-field-size="medium" style="display:none;">
+                            <label class="h3">聽力補充說明【選填】</label>
+                            <div class="checkcol" id="s1_hearing_detail_box"></div>
+                            <div id="s1_hearing_device_wrap" style="display:none; margin-top:var(--space-xs);">
+                              <label class="h4" for="s1_hearing_device_adherence">助聽／擴音依從性</label>
+                              <select id="s1_hearing_device_adherence">
+                                <option value="" class="placeholder-option" disabled selected>助聽／擴音依從性</option>
+                                <option>持續使用</option>
+                                <option>間斷使用</option>
+                                <option>不使用</option>
+                              </select>
+                            </div>
+                          </div>
                         </div>
                       </section>
                     </div>
-
-                    <div class="group" id="caseProfileSensoryGroup" data-collapsed="0">
-                      <div class="group-header">
-                        <span class="h3 heading-tier heading-tier--section">感官功能</span>
-                      </div>
-                      <div class="group-content">
-                        <div class="section-card-grid">
-                          <section class="section-card" id="caseProfileVisionCard">
-                            <span class="h5 heading-tier heading-tier--subsection">視力</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_vision">視力程度</label>
-                                <select id="s1_vision" onchange="toggleVisionNotes()">
-                                  <option>視力清晰</option>
-                                  <option>靠近才能辨識</option>
-                                  <option>即使配戴眼鏡，仍難以辨識</option>
-                                  <option>僅能分辨明暗，無法辨識人臉或物體輪廓</option>
-                                  <option>完全失去視覺功能，無法感知光線</option>
-                                </select>
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3">視力補充說明【選填】</label>
-                                <div class="checkcol" id="s1_vision_note_box"></div>
-                                <input id="s1_vision_other" type="text" placeholder="其他說明" style="display:none; margin-top:var(--space-xs);">
-                                <div id="s1_glasses_adherence_wrap" style="display:none; margin-top:var(--space-xs);">
-                                  <label class="h4" for="s1_glasses_adherence">配戴情形</label>
-                                  <select id="s1_glasses_adherence">
-                                    <option value="" class="placeholder-option" disabled selected>配戴情形</option>
-                                    <option>常態配戴</option>
-                                    <option>偶爾配戴</option>
-                                    <option>不配戴</option>
-                                  </select>
-                                </div>
-                                <div id="s1_vision_auto_hint" class="hint auto-hint" style="display:none; margin-top:var(--space-xs);">
-                                  <span>已依視力狀態預選建議補充（標記為「系統預選」）。</span>
-                                  <button type="button" class="small" onclick="resetVisionSuggestions()">還原為預設</button>
-                                </div>
-                              </div>
-                            </div>
-                          </section>
-                          <section class="section-card" id="caseProfileHearingCard">
-                            <span class="h5 heading-tier heading-tier--subsection">聽力</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_hearing_level">聽力程度</label>
-                                <select id="s1_hearing_level" onchange="renderHearingDetails()">
-                                  <option>無明顯異常</option>
-                                  <option>輕度受損</option>
-                                  <option>中度受損</option>
-                                  <option>重度受損</option>
-                                  <option>極重度受損</option>
-                                  <option>完全失聰</option>
-                                </select>
-                              </div>
-                              <div class="field" id="s1_hearing_detail_wrap" data-field-size="medium" style="display:none;">
-                                <label class="h3">聽力補充說明【選填】</label>
-                                <div class="checkcol" id="s1_hearing_detail_box"></div>
-                                <div id="s1_hearing_device_wrap" style="display:none; margin-top:var(--space-xs);">
-                                  <label class="h4" for="s1_hearing_device_adherence">助聽／擴音依從性</label>
-                                  <select id="s1_hearing_device_adherence">
-                                    <option value="" class="placeholder-option" disabled selected>助聽／擴音依從性</option>
-                                    <option>持續使用</option>
-                                    <option>間斷使用</option>
-                                    <option>不使用</option>
-                                  </select>
-                                </div>
-                              </div>
-                            </div>
-                          </section>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div class="group" id="caseProfileOralGroup" data-collapsed="0">
-                      <div class="group-header">
-                        <span class="h3 heading-tier heading-tier--section">口腔與吞嚥功能</span>
-                      </div>
-                      <div class="group-content">
-                        <div class="section-card-grid">
-                          <section class="section-card" id="caseProfileSwallowCard">
-                            <span class="h5 heading-tier heading-tier--subsection">吞嚥功能</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_swallow">吞嚥／嗆咳程度</label>
-                                <select id="s1_swallow" onchange="toggleSwallow()">
-                                  <option>無困難</option>
-                                  <option>輕度</option>
-                                  <option>明顯困難</option>
-                                  <option>危險（需專評）</option>
-                                </select>
-                              </div>
-                              <div class="field" id="s1_swallow_sx_wrap" data-field-size="medium" style="display:none;">
-                                <label class="h3">吞嚥症狀</label>
-                                <div id="s1_swallow_sx_hint" class="hint" style="display:none;">例：嗆咳、殘留、口水外漏等，勾選可快速完成紀錄。</div>
-                                <div class="checkcol" id="s1_swallow_sx_box"></div>
-                              </div>
-                              <div class="field" id="s1_diet_wrap" data-field-size="medium" style="display:none;">
-                                <label class="h3">飲食質地</label>
-                                <div class="checkcol" id="s1_diet_texture_box"></div>
-                                <span class="h4" style="margin-top:var(--space-sm); display:block;">管灌方式</span>
-                                <div class="checkcol" id="s1_feeding_tube_box"></div>
-                              </div>
-                            </div>
-                          </section>
-                          <section class="section-card" id="caseProfileOralCard">
-                            <span class="h5 heading-tier heading-tier--subsection">口腔與牙齒</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="long">
-                                <label class="h3">口腔牙齒／假牙</label>
-                                <div class="checkcol" id="s1_oral_box"></div>
-                                <input id="s1_oral_note" type="text" placeholder="備註" style="margin-top:var(--space-xs);">
-                              </div>
-                            </div>
-                          </section>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div class="group" id="caseProfileMobilityGroup" data-collapsed="0">
-                      <div class="group-header">
-                        <span class="h3 heading-tier heading-tier--section">移動功能</span>
-                      </div>
-                      <div class="group-content">
-                        <div class="section-card-grid">
-                          <section class="section-card" id="caseProfileMobilityCard">
-                            <span class="h5 heading-tier heading-tier--subsection">移動功能</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_transfer">起身／移位能力</label>
-                                <select id="s1_transfer" onchange="toggleAdlHow('s1_transfer')">
-                                  <option selected>獨立</option>
-                                  <option>需要輕扶</option>
-                                  <option>中度協助</option>
-                                  <option>重度協助</option>
-                                  <option>完全依賴</option>
-                                </select>
-                                <input id="s1_transfer_how" type="text" placeholder="請說明協助方式" style="display:none; margin-top:var(--space-xs);" data-show-values="中度協助,重度協助">
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_walk_indoor">室內行走能力</label>
-                                <select id="s1_walk_indoor">
-                                  <option selected>無輔具緩慢</option>
-                                  <option>單拐</option>
-                                  <option>四腳拐</option>
-                                  <option>助行器</option>
-                                  <option>輪椅</option>
-                                  <option>無法</option>
-                                </select>
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_walk_outdoor">外出行走能力</label>
-                                <select id="s1_walk_outdoor">
-                                  <option>獨立</option>
-                                  <option selected>單拐</option>
-                                  <option>四腳拐</option>
-                                  <option>助行器</option>
-                                  <option>輪椅</option>
-                                  <option>無法</option>
-                                </select>
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_stairs">上下樓梯能力</label>
-                                <select id="s1_stairs">
-                                  <option>可獨立</option>
-                                  <option selected>需扶手</option>
-                                  <option>需人協助</option>
-                                  <option>無法</option>
-                                </select>
-                              </div>
-                              <div class="field" data-field-size="short">
-                                <label class="h3" for="s1_weak_laterality">偏側無力</label>
-                                <select id="s1_weak_laterality">
-                                  <option>無</option>
-                                  <option>左側</option>
-                                  <option>右側</option>
-                                  <option>雙側</option>
-                                </select>
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_fall_history">跌倒史</label>
-                                <select id="s1_fall_history" onchange="toggleFallDetail()">
-                                  <option>無</option>
-                                  <option>過去1年1次</option>
-                                  <option>過去1年≧2次</option>
-                                  <option>不明</option>
-                                </select>
-                                <input id="s1_fall_times" type="number" min="0" placeholder="次數" style="display:none; margin-top:var(--space-xs);">
-                              </div>
-                              <div class="field" data-field-size="long">
-                                <label class="h3">平衡程度</label>
-                                <div class="checkcol" id="s1_balance_box"></div>
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_sitting_stability">坐姿穩定性與輪椅安全</label>
-                                <select id="s1_sitting_stability" onchange="toggleSittingSupports()">
-                                  <option value="" class="placeholder-option" disabled selected>請選擇</option>
-                                  <option>穩定</option>
-                                  <option>易前傾</option>
-                                  <option>易滑落</option>
-                                </select>
-                                <div class="checkcol" id="s1_sitting_support_box" style="display:none; margin-top:var(--space-xs);"></div>
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_gait">步態</label>
-                                <select id="s1_gait">
-                                  <option value="" class="placeholder-option" disabled selected>請選擇</option>
-                                  <option>正常</option>
-                                  <option>拖步</option>
-                                  <option>小碎步</option>
-                                  <option>步寬增大</option>
-                                  <option>偏斜</option>
-                                  <option>跨步不穩</option>
-                                  <option>其他</option>
-                                </select>
-                                <input id="s1_gait_note" type="text" placeholder="備註" style="margin-top:var(--space-xs);">
-                              </div>
-                            </div>
-                          </section>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div class="group" id="caseProfileAdlGroup" data-collapsed="0">
-                      <div class="group-header">
-                        <span class="h3 heading-tier heading-tier--section">ADL（日常生活活動）</span>
-                      </div>
-                      <div class="group-content">
-                        <div class="section-card-grid">
-                          <section class="section-card" id="caseProfileAdlCard">
-                            <span class="h5 heading-tier heading-tier--subsection">ADL 日常生活活動</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_adl_eating">進食</label>
-                                <select id="s1_adl_eating" onchange="toggleAdlHow('s1_adl_eating')">
-                                  <option selected>獨立</option>
-                                  <option>部分協助</option>
-                                  <option>完全協助</option>
-                                </select>
-                                <input id="s1_adl_eating_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_adl_eating" data-required-label="進食的部分協助方式">
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_adl_groom">盥洗（刷牙／洗臉）</label>
-                                <select id="s1_adl_groom" onchange="toggleAdlHow('s1_adl_groom')">
-                                  <option selected>獨立</option>
-                                  <option>部分協助</option>
-                                  <option>完全協助</option>
-                                </select>
-                                <input id="s1_adl_groom_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_adl_groom" data-required-label="刷牙/洗臉的部分協助方式">
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_adl_bathing">洗澡</label>
-                                <select id="s1_adl_bathing" onchange="toggleAdlHow('s1_adl_bathing')">
-                                  <option selected>獨立</option>
-                                  <option>部分協助</option>
-                                  <option>完全協助</option>
-                                </select>
-                                <input id="s1_adl_bathing_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_adl_bathing" data-required-label="洗澡的部分協助方式">
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_adl_dressing">穿脫衣</label>
-                                <select id="s1_adl_dressing" onchange="toggleAdlHow('s1_adl_dressing')">
-                                  <option selected>獨立</option>
-                                  <option>部分協助</option>
-                                  <option>完全協助</option>
-                                </select>
-                                <input id="s1_adl_dressing_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_adl_dressing" data-required-label="穿脫衣的部分協助方式">
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_post_toilet">如廁後清潔</label>
-                                <select id="s1_post_toilet" onchange="toggleAdlHow('s1_post_toilet')">
-                                  <option selected>獨立</option>
-                                  <option>部分協助</option>
-                                  <option>完全協助</option>
-                                </select>
-                                <input id="s1_post_toilet_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_post_toilet" data-required-label="如廁後清潔的部分協助方式">
-                              </div>
-                            </div>
-                          </section>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div class="group" id="caseProfileIadlGroup" data-collapsed="0">
-                      <div class="group-header">
-                        <span class="h3 heading-tier heading-tier--section">IADL（工具性日常活動）</span>
-                      </div>
-                      <div class="group-content">
-                        <div class="section-card-grid">
-                          <section class="section-card" id="caseProfileIadlCard">
-                            <span class="h5 heading-tier heading-tier--subsection">IADL 工具性日常活動</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_phone">電話使用</label>
-                                <select id="s1_phone" onchange="togglePhoneNotes()">
-                                  <option selected>會撥打與接聽</option>
-                                  <option>僅能接聽</option>
-                                  <option>不會使用</option>
-                                </select>
-                                <div id="s1_phone_note_wrap" style="display:none; margin-top:var(--space-xs);">
-                                  <div class="checkcol" id="s1_phone_note_box"></div>
-                                  <input id="s1_phone_note_other" type="text" placeholder="其他說明" style="display:none; margin-top:var(--space-xs);">
-                                </div>
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_shopping">外出購物</label>
-                                <select id="s1_shopping" onchange="toggleShoppingHow()">
-                                  <option>可獨立</option>
-                                  <option selected>需陪同</option>
-                                  <option>不外出</option>
-                                </select>
-                                <select id="s1_shopping_how" style="display:none; margin-top:var(--space-xs);" onchange="toggleShoppingHow()">
-                                  <option value="" class="placeholder-option" disabled selected>方式/說明</option>
-                                  <option>家屬陪同購物</option>
-                                  <option>由家屬代購</option>
-                                  <option>使用外送平台</option>
-                                  <option>居服員陪同／代購</option>
-                                  <option>外看（看護／志工）代購</option>
-                                  <option>其他</option>
-                                </select>
-                                <input id="s1_shopping_how_other" type="text" placeholder="請說明" style="display:none; margin-top:var(--space-xs);">
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_meal_prep">備餐</label>
-                                <select id="s1_meal_prep" onchange="toggleAdlHow('s1_meal_prep')">
-                                  <option>獨立</option>
-                                  <option selected>部分協助</option>
-                                  <option>完全由家屬</option>
-                                </select>
-                                <input id="s1_meal_prep_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_meal_prep" data-required-label="備餐的部分協助方式">
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_dishwash">餐具清洗</label>
-                                <select id="s1_dishwash" onchange="toggleDishwashHow()">
-                                  <option>乾淨</option>
-                                  <option selected>尚可或不一定乾淨</option>
-                                  <option>無法自行清洗</option>
-                                </select>
-                                <select id="s1_dishwash_how" style="display:none; margin-top:var(--space-xs);" onchange="toggleDishwashHow()">
-                                  <option>由他人代辦</option>
-                                  <option>其他</option>
-                                </select>
-                                <input id="s1_dishwash_how_other" type="text" placeholder="請說明" style="display:none; margin-top:var(--space-xs);">
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_housework">家務整理</label>
-                                <select id="s1_housework" onchange="toggleAdlHow('s1_housework')">
-                                  <option>獨立</option>
-                                  <option selected>部分協助</option>
-                                  <option>完全由家屬</option>
-                                </select>
-                                <input id="s1_housework_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_housework" data-required-label="家務整理的部分協助方式">
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_finance">財務管理</label>
-                                <select id="s1_finance" onchange="toggleAdlHow('s1_finance')">
-                                  <option selected>獨立</option>
-                                  <option>部分協助</option>
-                                  <option>他人代辦</option>
-                                </select>
-                                <input id="s1_finance_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_finance" data-required-label="財務管理的部分協助方式">
-                              </div>
-                            </div>
-                          </section>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div class="group" id="caseProfileExcretionGroup" data-collapsed="0">
-                      <div class="group-header">
-                        <span class="h3 heading-tier heading-tier--section">排泄功能</span>
-                      </div>
-                      <div class="group-content">
-                        <div class="section-card-grid">
-                          <section class="section-card" id="caseProfileExcretionCard">
-                            <span class="h5 heading-tier heading-tier--subsection">排泄功能</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="long">
-                                <label class="h3">排泄輔具</label>
-                                <div class="checkcol" id="s1_excretion_aids_box"></div>
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_urine_day">日間排尿情形</label>
-                                <select id="s1_urine_day" onchange="toggleUrineOther('day')">
-                                  <option selected>正常（4–6次）</option>
-                                  <option>偏少（少於3次）</option>
-                                  <option>偏多（7–9次）</option>
-                                  <option>失禁</option>
-                                  <option>其他</option>
-                                </select>
-                                <input id="s1_urine_day_other" type="text" placeholder="請說明" style="display:none; margin-top:var(--space-xs);">
-                              </div>
-                              <div class="field" id="s1_urine_night_wrap" data-field-size="medium">
-                                <label class="h3" for="s1_urine_night">夜間排尿情形</label>
-                                <select id="s1_urine_night" onchange="toggleUrineOther('night')">
-                                  <option selected>夜間未起夜</option>
-                                  <option>夜間起夜1次</option>
-                                  <option>夜間起夜2–3次</option>
-                                  <option>夜間起夜≥4次</option>
-                                  <option>夜間有尿失禁</option>
-                                  <option>其他</option>
-                                </select>
-                                <input id="s1_urine_night_other" type="text" placeholder="請說明" style="display:none; margin-top:var(--space-xs);">
-                              </div>
-                              <div class="field" id="s1_nocturia_wrap" data-field-size="short" style="display:none;">
-                                <label class="h3" for="s1_nocturia_count">夜尿次數數值</label>
-                                <input id="s1_nocturia_count" type="number" min="0" max="10" placeholder="0-10">
-                              </div>
-                            </div>
-                            <div id="s1_night_catheter_note" class="hint" style="display:none;">夜間以導尿／集尿袋處理，不以起夜次數評估</div>
-                          </section>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div class="group" id="caseProfileHealthGroup" data-collapsed="0">
-                      <div class="group-header">
-                        <span class="h3 heading-tier heading-tier--section">健康狀況與病史</span>
-                      </div>
-                      <div class="group-content">
-                        <div class="section-card-grid">
-                          <section class="section-card" id="caseProfileDiseaseCard">
-                            <span class="h5 heading-tier heading-tier--subsection">病史與過敏</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="long">
-                                <label class="h3">慢性病史</label>
-                                <div class="checkcol" id="s1_dhx_box"></div>
-                                <input id="s1_dhx_other" type="text" placeholder="其他慢性病" style="display:none; margin-top:var(--space-xs);">
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_surgery">手術史【選填】</label>
-                                <input id="s1_surgery" type="text" placeholder="例：10多年前髖關節手術">
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_allergy">藥物過敏【選填】</label>
-                                <input id="s1_allergy" type="text" placeholder="無則留空">
-                              </div>
-                            </div>
-                          </section>
-                          <section class="section-card" id="caseProfileMedicationCard">
-                            <span class="h5 heading-tier heading-tier--subsection">用藥與就醫</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="long">
-                                <label class="h3">現用藥物種類</label>
-                                <div class="checkcol" id="s1_med_classes_box"></div>
-                                <input id="s1_med_classes_other" type="text" placeholder="其他用藥" style="display:none; margin-top:var(--space-xs);">
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_follow_clinic">固定就醫單位【選填】</label>
-                                <input id="s1_follow_clinic" type="text" placeholder="例：嘉誠診所">
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_rx_type">處方型態【選填】</label>
-                                <select id="s1_rx_type">
-                                  <option>慢性處方箋</option>
-                                  <option>一般門診</option>
-                                </select>
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_med_manage">用藥管理方式</label>
-                                <select id="s1_med_manage">
-                                  <option>可自行規則服藥</option>
-                                  <option>需提醒</option>
-                                  <option>他人給藥</option>
-                                </select>
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_visit_transport">就醫交通方式【選填】</label>
-                                <select id="s1_visit_transport" onchange="toggleTransportOther()">
-                                  <option>計程車</option>
-                                  <option>家屬接送</option>
-                                  <option>交通接送服務</option>
-                                  <option>其他</option>
-                                </select>
-                                <input id="s1_visit_transport_other" type="text" placeholder="請填寫其他交通方式" style="display:none; margin-top:var(--space-xs);">
-                              </div>
-                            </div>
-                          </section>
-                          <section class="section-card" id="caseProfileDeviceCard">
-                            <span class="h5 heading-tier heading-tier--subsection">管路／裝置</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="long">
-                                <label class="h3">管路／裝置</label>
-                                <div class="checkcol" id="s1_devices_box"></div>
-                                <input id="s1_devices_note" type="text" placeholder="備註" style="margin-top:var(--space-xs);">
-                              </div>
-                            </div>
-                          </section>
-                          <section class="section-card" id="caseProfileDisabilityCard">
-                            <span class="h5 heading-tier heading-tier--subsection">身心障礙資訊</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="medium">
-                                <label class="h3">身心障礙等級</label>
-                                <div id="s1_dis_level_text" class="badge">—</div>
-                              </div>
-                              <div class="field" id="s1_dis_cat_box" data-field-size="medium" style="display:none;">
-                                <label class="h3">身心障礙類別</label>
-                                <div id="s1_dis_cat_text" class="badge">—</div>
-                              </div>
-                            </div>
-                            <div class="hint" style="margin-top:var(--space-xs);">身心障礙資訊同步自(二)經濟收入，此處為唯讀顯示。</div>
-                          </section>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div class="group" id="caseProfilePsychGroup" data-collapsed="0">
-                      <div class="group-header">
-                        <span class="h3 heading-tier heading-tier--section">心理與行為狀態</span>
-                      </div>
-                      <div class="group-content">
-                        <div class="section-card-grid">
-                          <section class="section-card" id="caseProfilePsychBehaviorCard">
-                            <span class="h5 heading-tier heading-tier--subsection">心理與行為</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="medium">
-                                <label class="h3">情緒狀態</label>
-                                <div class="checkcol" id="s1_emotion_box"></div>
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3">行為表現</label>
-                                <div class="checkcol" id="s1_behavior_box"></div>
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_motivation">執行動機與督促需求</label>
-                                <select id="s1_motivation">
-                                  <option value="" class="placeholder-option" disabled selected>請選擇</option>
-                                  <option>主動配合</option>
-                                  <option>需提醒／督促</option>
-                                  <option>拒絕／抗拒</option>
-                                </select>
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_cognition">認知功能【選填】</label>
-                                <select id="s1_cognition">
-                                  <option>清楚可應答</option>
-                                  <option>需重複或放慢</option>
-                                  <option>健忘／短期記憶不佳</option>
-                                  <option>表達或理解困難</option>
-                                  <option>無法溝通</option>
-                                  <option>無法評估</option>
-                                </select>
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_awareness">意識狀態【選填】</label>
-                                <select id="s1_awareness">
-                                  <option>清楚</option>
-                                  <option>遲鈍</option>
-                                  <option>混亂</option>
-                                  <option>模糊</option>
-                                  <option>嗜睡</option>
-                                  <option>昏迷</option>
-                                </select>
-                              </div>
-                            </div>
-                          </section>
-                          <section class="section-card" id="caseProfilePsychSleepCard">
-                            <span class="h5 heading-tier heading-tier--subsection">睡眠與日間活動</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_sleep">睡眠品質</label>
-                                <select id="s1_sleep" onchange="toggleSleepReason()">
-                                  <option>良好</option>
-                                  <option>尚可</option>
-                                  <option selected>不佳</option>
-                                </select>
-                                <select id="s1_sleep_reason" style="display:none; margin-top:var(--space-xs);" onchange="toggleSleepReasonDetail()">
-                                  <option value="" class="placeholder-option" disabled selected>失眠原因</option>
-                                  <option>疼痛</option>
-                                  <option>頻尿</option>
-                                  <option>慢性疾病</option>
-                                  <option>焦慮、憂鬱</option>
-                                  <option>生活壓力</option>
-                                  <option>環境干擾</option>
-                                  <option>不良睡眠習慣</option>
-                                  <option>日夜顛倒</option>
-                                  <option>藥物影響</option>
-                                  <option>咖啡因</option>
-                                  <option>酒精</option>
-                                  <option>其他</option>
-                                </select>
-                                <select id="s1_sleep_reason_detail" style="display:none; margin-top:var(--space-xs);"></select>
-                                <input id="s1_sleep_reason_other" type="text" placeholder="請說明" style="display:none; margin-top:var(--space-xs);">
-                              </div>
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_daytime">白天活動【選填】</label>
-                                <input id="s1_daytime" type="text" placeholder="例：坐後門外看電視，累了打盹">
-                              </div>
-                            </div>
-                          </section>
-                          <section class="section-card" id="caseProfilePainSkinCard">
-                            <span class="h5 heading-tier heading-tier--subsection">疼痛與皮膚狀態</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_pain">疼痛【選填】</label>
-                                <select id="s1_pain" onchange="togglePainCombined()">
-                                  <option selected>無</option>
-                                  <option>有</option>
-                                  <option>未知</option>
-                                </select>
-                              </div>
-                              <div class="field" id="s1_pain_score_wrap" data-field-size="short" style="display:none;">
-                                <label class="h3" for="s1_pain_score">疼痛強度（1-10）</label>
-                                <input id="s1_pain_score" type="number" min="1" max="10" step="1">
-                                <div class="field-error" id="s1_pain_score_error"></div>
-                              </div>
-                            </div>
-                            <div id="s1_location_block" style="display:none;" data-level="advanced">
-                              <div class="location-toolbar" id="s1_location_toolbar" style="display:none;">
-                                <span class="location-current">目前編輯：<span id="s1_location_active_label">疼痛部位</span></span>
-                                <div class="location-switch btnbar">
-                                  <button type="button" class="small" data-context="pain" onclick="switchLocationContext('pain')">編輯疼痛部位</button>
-                                  <button type="button" class="small" data-context="lesion" onclick="switchLocationContext('lesion')">編輯病灶部位</button>
-                                </div>
-                                <div class="location-actions btnbar">
-                                  <button type="button" class="small" id="location_copy_btn" onclick="copyLocationFromOther()">同疼痛部位</button>
-                                </div>
-                              </div>
-                              <div class="autogrid autogrid--wide">
-                                <div class="field" data-field-size="medium">
-                                  <label class="h3" for="s1_location_region">部位大分類</label>
-                                  <select id="s1_location_region" onchange="onSharedRegionChange()">
-                                    <option value="" class="placeholder-option" disabled selected>請選擇</option>
-                                    <option>頭頸部</option>
-                                    <option>上肢</option>
-                                    <option>軀幹</option>
-                                    <option>下肢</option>
-                                    <option>全身性</option>
-                                  </select>
-                                </div>
-                                <div class="field" data-field-size="medium">
-                                  <label class="h3" for="s1_location_subregion">細部分位</label>
-                                  <select id="s1_location_subregion" onchange="onSharedSubregionChange()">
-                                    <option value="" class="placeholder-option" disabled selected>請選擇</option>
-                                  </select>
-                                  <input id="s1_location_subregion_other" type="text" placeholder="請填寫其他部位" style="display:none; margin-top:var(--space-xs);" oninput="onSharedSubregionOtherInput()">
-                                </div>
-                                <div class="field" data-field-size="short">
-                                  <label class="h3" for="s1_location_laterality">側別</label>
-                                  <select id="s1_location_laterality" onchange="onSharedLateralityChange()">
-                                    <option value="" class="placeholder-option" disabled selected>請選擇</option>
-                                    <option>左側</option>
-                                    <option>右側</option>
-                                    <option>雙側</option>
-                                  </select>
-                                </div>
-                              </div>
-                            </div>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="medium">
-                                <label class="h3" for="s1_lesion_has">皮膚病灶【選填】</label>
-                                <select id="s1_lesion_has" onchange="toggleLesionCombined()">
-                                  <option selected>無</option>
-                                  <option>有</option>
-                                  <option>未知</option>
-                                </select>
-                              </div>
-                              <div class="field" id="s1_lesion_layer_wrap" data-field-size="medium" style="display:none;">
-                                <label class="h3" for="s1_lesion_layer">病灶層次</label>
-                                <select id="s1_lesion_layer" onchange="toggleLesionLayerOther()">
-                                  <option>無</option>
-                                  <option>表皮</option>
-                                  <option>皮下</option>
-                                  <option>關節附近</option>
-                                  <option>其他</option>
-                                </select>
-                                <input id="s1_lesion_layer_other" type="text" placeholder="請填寫" style="display:none; margin-top:var(--space-xs);">
-                              </div>
-                              <div class="field" id="s1_lesion_size_wrap" data-field-size="medium" style="display:none;">
-                                <label class="h3">病灶大小</label>
-                                <div class="lesion-size-grid">
-                                  <div class="lesion-size-field">
-                                    <input id="s1_lesion_length" type="number" min="0" step="0.1" placeholder="長" oninput="updateLesionAreaDisplay()">
-                                    <span class="unit">cm</span>
-                                  </div>
-                                  <div class="lesion-size-field">
-                                    <input id="s1_lesion_width" type="number" min="0" step="0.1" placeholder="寬" oninput="updateLesionAreaDisplay()">
-                                    <span class="unit">cm</span>
-                                  </div>
-                                </div>
-                                <div class="hint" id="s1_lesion_size_hint">請輸入長與寬，系統將即時計算面積。</div>
-                                <div class="lesion-area" id="s1_lesion_area_display">面積：— cm²</div>
-                                <div class="field-error" id="s1_lesion_size_error"></div>
-                              </div>
-                            </div>
-                            <div id="s1_lesion_more" style="display:none;" data-level="advanced">
-                              <div class="autogrid autogrid--wide">
-                                <div class="field" data-field-size="medium">
-                                  <label class="h3">病灶症狀</label>
-                                  <div class="lesion-mode" id="s1_lesion_mode">
-                                    <button type="button" class="small" data-mode="none" onclick="setLesionSymptomMode('none')">無不適</button>
-                                    <button type="button" class="small" data-mode="symptom" onclick="setLesionSymptomMode('symptom')">有症狀</button>
-                                  </div>
-                                  <div class="checkcol" id="s1_lesion_sx_box"></div>
-                                </div>
-                                <div class="field" data-field-size="medium">
-                                  <label class="h3" for="s1_lesion_eval">醫療評估</label>
-                                  <select id="s1_lesion_eval" onchange="toggleLesionHospital()">
-                                    <option>未評估</option>
-                                    <option>醫師評估無大礙</option>
-                                    <option>已安排追蹤</option>
-                                    <option>持續治療中</option>
-                                  </select>
-                                  <input id="s1_lesion_hospital" type="text" placeholder="醫療院所名稱" style="display:none; margin-top:var(--space-xs);">
-                                </div>
-                              </div>
-                            </div>
-                            <div class="field-error" id="s1_pain_location_error"></div>
-                          </section>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div class="group" id="caseProfileSummaryGroup" data-collapsed="0">
-                      <div class="group-header">
-                        <span class="h3 heading-tier heading-tier--section">總結建議</span>
-                      </div>
-                      <div class="group-content">
-                        <div class="section-card-grid">
-                          <section class="section-card" id="caseProfileActionsCard">
-                            <div class="titlebar">
-                              <span class="h5 heading-tier heading-tier--subsection">建議措施</span>
-                              <button type="button" class="small" onclick="addActionEntry()">＋新增</button>
-                            </div>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="long">
-                                <div id="s1_actions_list" class="action-list"></div>
-                                <div class="hint" id="s1_actions_hint" style="display:none;">尚未新增建議措施。</div>
-                                <div class="field-error" id="s1_actions_error"></div>
-                              </div>
-                            </div>
-                          </section>
-                          <section class="section-card" id="caseProfileNotesCard">
-                            <span class="h5 heading-tier heading-tier--subsection">補充內容</span>
-                            <div class="autogrid autogrid--wide">
-                              <div class="field" data-field-size="long">
-                                <label class="h3" for="s1_notes">補充內容【選填】</label>
-                                <textarea id="s1_notes" placeholder="其他未涵蓋重點（限簡要）；將附加於段落末端。"></textarea>
-                              </div>
-                            </div>
-                          </section>
-                        </div>
-                        <textarea id="section1_out" style="display:none;" data-progress-ignore="1"></textarea>
-                        <div id="section1_errors" class="error-messages" data-progress-ignore="1"></div>
-                        <div class="preview-toolbar" style="margin-top:var(--space-xs);">
-                          <span class="hint">預覽（主題分段）：</span>
-                          <button type="button" class="small preview-toggle" id="section1_diff_toggle" data-active="0">只看變更</button>
-                        </div>
-                        <div id="section1_rule_errors" class="error-messages" data-progress-ignore="1"></div>
-                        <div id="section1_preview_cards" class="preview-card-container" data-empty="1">
-                          <div class="preview-empty">尚未產生預覽內容。</div>
-                        </div>
-                      </div>
-                    </div>
                   </div>
-    
-            <div id="section2_block" data-section="s2">
-                  <div class="titlebar">
-                    <label class="h3 heading-tier heading-tier--primary">（二）經濟收入</label>
+                </div>
+
+                <div class="group" id="caseProfileOralGroup" data-collapsed="0">
+                  <div class="group-header">
+                    <span class="h3 heading-tier heading-tier--section">口腔與吞嚥功能</span>
                   </div>
-                    <div class="autogrid autogrid--wide">
-                      <div>
-                        <label class="h4">主要經濟來源</label>
-                        <div class="checkcol" id="s2_sources"></div>
-                      </div>
-                      <div>
+                  <div class="group-content">
+                    <div class="section-card-grid">
+                      <section class="section-card" id="caseProfileSwallowCard">
+                        <span class="h5 heading-tier heading-tier--subsection">吞嚥功能</span>
                         <div class="autogrid autogrid--wide">
-                          <div>
-                            <label class="h4">戶籍／福利身分</label>
-                            <select id="s2_id">
-                              <option>一般戶</option><option>中低收入戶</option><option>低收入戶</option>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_swallow">吞嚥／嗆咳程度</label>
+                            <select id="s1_swallow" onchange="toggleSwallow()">
+                              <option>無困難</option>
+                              <option>輕度</option>
+                              <option>明顯困難</option>
+                              <option>危險（需專評）</option>
                             </select>
                           </div>
-                          <div>
-                            <label class="h4">身心障礙等級</label>
-                            <select id="s2_dis_level" onchange="syncDisab()"><!-- 選擇身心障礙等級 -->
-                              <option>無</option><option>輕度</option><option>中度</option><option>重度</option><option>極重度</option>
+                          <div class="field" id="s1_swallow_sx_wrap" data-field-size="medium" style="display:none;">
+                            <label class="h3">吞嚥症狀</label>
+                            <div id="s1_swallow_sx_hint" class="hint" style="display:none;">例：嗆咳、殘留、口水外漏等，勾選可快速完成紀錄。</div>
+                            <div class="checkcol" id="s1_swallow_sx_box"></div>
+                          </div>
+                          <div class="field" id="s1_diet_wrap" data-field-size="medium" style="display:none;">
+                            <label class="h3">飲食質地</label>
+                            <div class="checkcol" id="s1_diet_texture_box"></div>
+                            <span class="h4" style="margin-top:var(--space-sm); display:block;">管灌方式</span>
+                            <div class="checkcol" id="s1_feeding_tube_box"></div>
+                          </div>
+                        </div>
+                      </section>
+                      <section class="section-card" id="caseProfileOralCard">
+                        <span class="h5 heading-tier heading-tier--subsection">口腔與牙齒</span>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="long">
+                            <label class="h3">口腔牙齒／假牙</label>
+                            <div class="checkcol" id="s1_oral_box"></div>
+                            <input id="s1_oral_note" type="text" placeholder="備註" style="margin-top:var(--space-xs);">
+                          </div>
+                        </div>
+                      </section>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="group" id="caseProfileMobilityGroup" data-collapsed="0">
+                  <div class="group-header">
+                    <span class="h3 heading-tier heading-tier--section">移動功能</span>
+                  </div>
+                  <div class="group-content">
+                    <div class="section-card-grid">
+                      <section class="section-card" id="caseProfileMobilityCard">
+                        <span class="h5 heading-tier heading-tier--subsection">移動功能</span>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_transfer">起身／移位能力</label>
+                            <select id="s1_transfer" onchange="toggleAdlHow('s1_transfer')">
+                              <option selected>獨立</option>
+                              <option>需要輕扶</option>
+                              <option>中度協助</option>
+                              <option>重度協助</option>
+                              <option>完全依賴</option>
+                            </select>
+                            <input id="s1_transfer_how" type="text" placeholder="請說明協助方式" style="display:none; margin-top:var(--space-xs);" data-show-values="中度協助,重度協助">
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_walk_indoor">室內行走能力</label>
+                            <select id="s1_walk_indoor">
+                              <option selected>無輔具緩慢</option>
+                              <option>單拐</option>
+                              <option>四腳拐</option>
+                              <option>助行器</option>
+                              <option>輪椅</option>
+                              <option>無法</option>
+                            </select>
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_walk_outdoor">外出行走能力</label>
+                            <select id="s1_walk_outdoor">
+                              <option>獨立</option>
+                              <option selected>單拐</option>
+                              <option>四腳拐</option>
+                              <option>助行器</option>
+                              <option>輪椅</option>
+                              <option>無法</option>
+                            </select>
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_stairs">上下樓梯能力</label>
+                            <select id="s1_stairs">
+                              <option>可獨立</option>
+                              <option selected>需扶手</option>
+                              <option>需人協助</option>
+                              <option>無法</option>
+                            </select>
+                          </div>
+                          <div class="field" data-field-size="short">
+                            <label class="h3" for="s1_weak_laterality">偏側無力</label>
+                            <select id="s1_weak_laterality">
+                              <option>無</option>
+                              <option>左側</option>
+                              <option>右側</option>
+                              <option>雙側</option>
+                            </select>
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_fall_history">跌倒史</label>
+                            <select id="s1_fall_history" onchange="toggleFallDetail()">
+                              <option>無</option>
+                              <option>過去1年1次</option>
+                              <option>過去1年≧2次</option>
+                              <option>不明</option>
+                            </select>
+                            <input id="s1_fall_times" type="number" min="0" placeholder="次數" style="display:none; margin-top:var(--space-xs);">
+                          </div>
+                          <div class="field" data-field-size="long">
+                            <label class="h3">平衡程度</label>
+                            <div class="checkcol" id="s1_balance_box"></div>
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_sitting_stability">坐姿穩定性與輪椅安全</label>
+                            <select id="s1_sitting_stability" onchange="toggleSittingSupports()">
+                              <option value="" class="placeholder-option" disabled selected>請選擇</option>
+                              <option>穩定</option>
+                              <option>易前傾</option>
+                              <option>易滑落</option>
+                            </select>
+                            <div class="checkcol" id="s1_sitting_support_box" style="display:none; margin-top:var(--space-xs);"></div>
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_gait">步態</label>
+                            <select id="s1_gait">
+                              <option value="" class="placeholder-option" disabled selected>請選擇</option>
+                              <option>正常</option>
+                              <option>拖步</option>
+                              <option>小碎步</option>
+                              <option>步寬增大</option>
+                              <option>偏斜</option>
+                              <option>跨步不穩</option>
+                              <option>其他</option>
+                            </select>
+                            <input id="s1_gait_note" type="text" placeholder="備註" style="margin-top:var(--space-xs);">
+                          </div>
+                        </div>
+                      </section>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="group" id="caseProfileAdlGroup" data-collapsed="0">
+                  <div class="group-header">
+                    <span class="h3 heading-tier heading-tier--section">ADL（日常生活活動）</span>
+                  </div>
+                  <div class="group-content">
+                    <div class="section-card-grid">
+                      <section class="section-card" id="caseProfileAdlCard">
+                        <span class="h5 heading-tier heading-tier--subsection">ADL 日常生活活動</span>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_adl_eating">進食</label>
+                            <select id="s1_adl_eating" onchange="toggleAdlHow('s1_adl_eating')">
+                              <option selected>獨立</option>
+                              <option>部分協助</option>
+                              <option>完全協助</option>
+                            </select>
+                            <input id="s1_adl_eating_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_adl_eating" data-required-label="進食的部分協助方式">
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_adl_groom">盥洗（刷牙／洗臉）</label>
+                            <select id="s1_adl_groom" onchange="toggleAdlHow('s1_adl_groom')">
+                              <option selected>獨立</option>
+                              <option>部分協助</option>
+                              <option>完全協助</option>
+                            </select>
+                            <input id="s1_adl_groom_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_adl_groom" data-required-label="刷牙/洗臉的部分協助方式">
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_adl_bathing">洗澡</label>
+                            <select id="s1_adl_bathing" onchange="toggleAdlHow('s1_adl_bathing')">
+                              <option selected>獨立</option>
+                              <option>部分協助</option>
+                              <option>完全協助</option>
+                            </select>
+                            <input id="s1_adl_bathing_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_adl_bathing" data-required-label="洗澡的部分協助方式">
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_adl_dressing">穿脫衣</label>
+                            <select id="s1_adl_dressing" onchange="toggleAdlHow('s1_adl_dressing')">
+                              <option selected>獨立</option>
+                              <option>部分協助</option>
+                              <option>完全協助</option>
+                            </select>
+                            <input id="s1_adl_dressing_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_adl_dressing" data-required-label="穿脫衣的部分協助方式">
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_post_toilet">如廁後清潔</label>
+                            <select id="s1_post_toilet" onchange="toggleAdlHow('s1_post_toilet')">
+                              <option selected>獨立</option>
+                              <option>部分協助</option>
+                              <option>完全協助</option>
+                            </select>
+                            <input id="s1_post_toilet_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_post_toilet" data-required-label="如廁後清潔的部分協助方式">
+                          </div>
+                        </div>
+                      </section>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="group" id="caseProfileIadlGroup" data-collapsed="0">
+                  <div class="group-header">
+                    <span class="h3 heading-tier heading-tier--section">IADL（工具性日常活動）</span>
+                  </div>
+                  <div class="group-content">
+                    <div class="section-card-grid">
+                      <section class="section-card" id="caseProfileIadlCard">
+                        <span class="h5 heading-tier heading-tier--subsection">IADL 工具性日常活動</span>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_phone">電話使用</label>
+                            <select id="s1_phone" onchange="togglePhoneNotes()">
+                              <option selected>會撥打與接聽</option>
+                              <option>僅能接聽</option>
+                              <option>不會使用</option>
+                            </select>
+                            <div id="s1_phone_note_wrap" style="display:none; margin-top:var(--space-xs);">
+                              <div class="checkcol" id="s1_phone_note_box"></div>
+                              <input id="s1_phone_note_other" type="text" placeholder="其他說明" style="display:none; margin-top:var(--space-xs);">
+                            </div>
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_shopping">外出購物</label>
+                            <select id="s1_shopping" onchange="toggleShoppingHow()">
+                              <option>可獨立</option>
+                              <option selected>需陪同</option>
+                              <option>不外出</option>
+                            </select>
+                            <select id="s1_shopping_how" style="display:none; margin-top:var(--space-xs);" onchange="toggleShoppingHow()">
+                              <option value="" class="placeholder-option" disabled selected>方式/說明</option>
+                              <option>家屬陪同購物</option>
+                              <option>由家屬代購</option>
+                              <option>使用外送平台</option>
+                              <option>居服員陪同／代購</option>
+                              <option>外看（看護／志工）代購</option>
+                              <option>其他</option>
+                            </select>
+                            <input id="s1_shopping_how_other" type="text" placeholder="請說明" style="display:none; margin-top:var(--space-xs);">
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_meal_prep">備餐</label>
+                            <select id="s1_meal_prep" onchange="toggleAdlHow('s1_meal_prep')">
+                              <option>獨立</option>
+                              <option selected>部分協助</option>
+                              <option>完全由家屬</option>
+                            </select>
+                            <input id="s1_meal_prep_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_meal_prep" data-required-label="備餐的部分協助方式">
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_dishwash">餐具清洗</label>
+                            <select id="s1_dishwash" onchange="toggleDishwashHow()">
+                              <option>乾淨</option>
+                              <option selected>尚可或不一定乾淨</option>
+                              <option>無法自行清洗</option>
+                            </select>
+                            <select id="s1_dishwash_how" style="display:none; margin-top:var(--space-xs);" onchange="toggleDishwashHow()">
+                              <option>由他人代辦</option>
+                              <option>其他</option>
+                            </select>
+                            <input id="s1_dishwash_how_other" type="text" placeholder="請說明" style="display:none; margin-top:var(--space-xs);">
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_housework">家務整理</label>
+                            <select id="s1_housework" onchange="toggleAdlHow('s1_housework')">
+                              <option>獨立</option>
+                              <option selected>部分協助</option>
+                              <option>完全由家屬</option>
+                            </select>
+                            <input id="s1_housework_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_housework" data-required-label="家務整理的部分協助方式">
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_finance">財務管理</label>
+                            <select id="s1_finance" onchange="toggleAdlHow('s1_finance')">
+                              <option selected>獨立</option>
+                              <option>部分協助</option>
+                              <option>他人代辦</option>
+                            </select>
+                            <input id="s1_finance_how" type="text" placeholder="部分協助方式" style="display:none; margin-top:var(--space-xs);" data-required-when="partial" data-required-source="s1_finance" data-required-label="財務管理的部分協助方式">
+                          </div>
+                        </div>
+                      </section>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="group" id="caseProfileExcretionGroup" data-collapsed="0">
+                  <div class="group-header">
+                    <span class="h3 heading-tier heading-tier--section">排泄功能</span>
+                  </div>
+                  <div class="group-content">
+                    <div class="section-card-grid">
+                      <section class="section-card" id="caseProfileExcretionCard">
+                        <span class="h5 heading-tier heading-tier--subsection">排泄功能</span>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="long">
+                            <label class="h3">排泄輔具</label>
+                            <div class="checkcol" id="s1_excretion_aids_box"></div>
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_urine_day">日間排尿情形</label>
+                            <select id="s1_urine_day" onchange="toggleUrineOther('day')">
+                              <option selected>正常（4–6次）</option>
+                              <option>偏少（少於3次）</option>
+                              <option>偏多（7–9次）</option>
+                              <option>失禁</option>
+                              <option>其他</option>
+                            </select>
+                            <input id="s1_urine_day_other" type="text" placeholder="請說明" style="display:none; margin-top:var(--space-xs);">
+                          </div>
+                          <div class="field" id="s1_urine_night_wrap" data-field-size="medium">
+                            <label class="h3" for="s1_urine_night">夜間排尿情形</label>
+                            <select id="s1_urine_night" onchange="toggleUrineOther('night')">
+                              <option selected>夜間未起夜</option>
+                              <option>夜間起夜1次</option>
+                              <option>夜間起夜2–3次</option>
+                              <option>夜間起夜≥4次</option>
+                              <option>夜間有尿失禁</option>
+                              <option>其他</option>
+                            </select>
+                            <input id="s1_urine_night_other" type="text" placeholder="請說明" style="display:none; margin-top:var(--space-xs);">
+                          </div>
+                          <div class="field" id="s1_nocturia_wrap" data-field-size="short" style="display:none;">
+                            <label class="h3" for="s1_nocturia_count">夜尿次數數值</label>
+                            <input id="s1_nocturia_count" type="number" min="0" max="10" placeholder="0-10">
+                          </div>
+                        </div>
+                        <div id="s1_night_catheter_note" class="hint" style="display:none;">夜間以導尿／集尿袋處理，不以起夜次數評估</div>
+                      </section>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="group" id="caseProfileHealthGroup" data-collapsed="0">
+                  <div class="group-header">
+                    <span class="h3 heading-tier heading-tier--section">健康狀況與病史</span>
+                  </div>
+                  <div class="group-content">
+                    <div class="section-card-grid">
+                      <section class="section-card" id="caseProfileDiseaseCard">
+                        <span class="h5 heading-tier heading-tier--subsection">病史與過敏</span>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="long">
+                            <label class="h3">慢性病史</label>
+                            <div class="checkcol" id="s1_dhx_box"></div>
+                            <input id="s1_dhx_other" type="text" placeholder="其他慢性病" style="display:none; margin-top:var(--space-xs);">
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_surgery">手術史【選填】</label>
+                            <input id="s1_surgery" type="text" placeholder="例：10多年前髖關節手術">
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_allergy">藥物過敏【選填】</label>
+                            <input id="s1_allergy" type="text" placeholder="無則留空">
+                          </div>
+                        </div>
+                      </section>
+                      <section class="section-card" id="caseProfileMedicationCard">
+                        <span class="h5 heading-tier heading-tier--subsection">用藥與就醫</span>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="long">
+                            <label class="h3">現用藥物種類</label>
+                            <div class="checkcol" id="s1_med_classes_box"></div>
+                            <input id="s1_med_classes_other" type="text" placeholder="其他用藥" style="display:none; margin-top:var(--space-xs);">
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_follow_clinic">固定就醫單位【選填】</label>
+                            <input id="s1_follow_clinic" type="text" placeholder="例：嘉誠診所">
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_rx_type">處方型態【選填】</label>
+                            <select id="s1_rx_type">
+                              <option>慢性處方箋</option>
+                              <option>一般門診</option>
+                            </select>
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_med_manage">用藥管理方式</label>
+                            <select id="s1_med_manage">
+                              <option>可自行規則服藥</option>
+                              <option>需提醒</option>
+                              <option>他人給藥</option>
+                            </select>
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_visit_transport">就醫交通方式【選填】</label>
+                            <select id="s1_visit_transport" onchange="toggleTransportOther()">
+                              <option>計程車</option>
+                              <option>家屬接送</option>
+                              <option>交通接送服務</option>
+                              <option>其他</option>
+                            </select>
+                            <input id="s1_visit_transport_other" type="text" placeholder="請填寫其他交通方式" style="display:none; margin-top:var(--space-xs);">
+                          </div>
+                        </div>
+                      </section>
+                      <section class="section-card" id="caseProfileDeviceCard">
+                        <span class="h5 heading-tier heading-tier--subsection">管路／裝置</span>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="long">
+                            <label class="h3">管路／裝置</label>
+                            <div class="checkcol" id="s1_devices_box"></div>
+                            <input id="s1_devices_note" type="text" placeholder="備註" style="margin-top:var(--space-xs);">
+                          </div>
+                        </div>
+                      </section>
+                      <section class="section-card" id="caseProfileDisabilityCard">
+                        <span class="h5 heading-tier heading-tier--subsection">身心障礙資訊</span>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="medium">
+                            <label class="h3">身心障礙等級</label>
+                            <div id="s1_dis_level_text" class="badge">—</div>
+                          </div>
+                          <div class="field" id="s1_dis_cat_box" data-field-size="medium" style="display:none;">
+                            <label class="h3">身心障礙類別</label>
+                            <div id="s1_dis_cat_text" class="badge">—</div>
+                          </div>
+                        </div>
+                        <div class="hint" style="margin-top:var(--space-xs);">身心障礙資訊同步自(二)經濟收入，此處為唯讀顯示。</div>
+                      </section>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="group" id="caseProfilePsychGroup" data-collapsed="0">
+                  <div class="group-header">
+                    <span class="h3 heading-tier heading-tier--section">心理與行為狀態</span>
+                  </div>
+                  <div class="group-content">
+                    <div class="section-card-grid">
+                      <section class="section-card" id="caseProfilePsychBehaviorCard">
+                        <span class="h5 heading-tier heading-tier--subsection">心理與行為</span>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="medium">
+                            <label class="h3">情緒狀態</label>
+                            <div class="checkcol" id="s1_emotion_box"></div>
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3">行為表現</label>
+                            <div class="checkcol" id="s1_behavior_box"></div>
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_motivation">執行動機與督促需求</label>
+                            <select id="s1_motivation">
+                              <option value="" class="placeholder-option" disabled selected>請選擇</option>
+                              <option>主動配合</option>
+                              <option>需提醒／督促</option>
+                              <option>拒絕／抗拒</option>
+                            </select>
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_cognition">認知功能【選填】</label>
+                            <select id="s1_cognition">
+                              <option>清楚可應答</option>
+                              <option>需重複或放慢</option>
+                              <option>健忘／短期記憶不佳</option>
+                              <option>表達或理解困難</option>
+                              <option>無法溝通</option>
+                              <option>無法評估</option>
+                            </select>
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_awareness">意識狀態【選填】</label>
+                            <select id="s1_awareness">
+                              <option>清楚</option>
+                              <option>遲鈍</option>
+                              <option>混亂</option>
+                              <option>模糊</option>
+                              <option>嗜睡</option>
+                              <option>昏迷</option>
                             </select>
                           </div>
                         </div>
-                        <div id="disCatBox" style="display:none; margin-top:var(--space-xs);"><!-- 類別欄位，預設隱藏 -->
-                          <label class="h4">身心障礙類別（等級≠無才需選）</label>
-                          <select id="s2_dis_cat" onchange="syncDisab()"><!-- 選擇身心障礙類別 --></select>
+                      </section>
+                      <section class="section-card" id="caseProfilePsychSleepCard">
+                        <span class="h5 heading-tier heading-tier--subsection">睡眠與日間活動</span>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_sleep">睡眠品質</label>
+                            <select id="s1_sleep" onchange="toggleSleepReason()">
+                              <option>良好</option>
+                              <option>尚可</option>
+                              <option selected>不佳</option>
+                            </select>
+                            <select id="s1_sleep_reason" style="display:none; margin-top:var(--space-xs);" onchange="toggleSleepReasonDetail()">
+                              <option value="" class="placeholder-option" disabled selected>失眠原因</option>
+                              <option>疼痛</option>
+                              <option>頻尿</option>
+                              <option>慢性疾病</option>
+                              <option>焦慮、憂鬱</option>
+                              <option>生活壓力</option>
+                              <option>環境干擾</option>
+                              <option>不良睡眠習慣</option>
+                              <option>日夜顛倒</option>
+                              <option>藥物影響</option>
+                              <option>咖啡因</option>
+                              <option>酒精</option>
+                              <option>其他</option>
+                            </select>
+                            <select id="s1_sleep_reason_detail" style="display:none; margin-top:var(--space-xs);"></select>
+                            <input id="s1_sleep_reason_other" type="text" placeholder="請說明" style="display:none; margin-top:var(--space-xs);">
+                          </div>
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_daytime">白天活動【選填】</label>
+                            <input id="s1_daytime" type="text" placeholder="例：坐後門外看電視，累了打盹">
+                          </div>
                         </div>
-                      </div>
+                      </section>
+                      <section class="section-card" id="caseProfilePainSkinCard">
+                        <span class="h5 heading-tier heading-tier--subsection">疼痛與皮膚狀態</span>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_pain">疼痛【選填】</label>
+                            <select id="s1_pain" onchange="togglePainCombined()">
+                              <option selected>無</option>
+                              <option>有</option>
+                              <option>未知</option>
+                            </select>
+                          </div>
+                          <div class="field" id="s1_pain_score_wrap" data-field-size="short" style="display:none;">
+                            <label class="h3" for="s1_pain_score">疼痛強度（1-10）</label>
+                            <input id="s1_pain_score" type="number" min="1" max="10" step="1">
+                            <div class="field-error" id="s1_pain_score_error"></div>
+                          </div>
+                        </div>
+                        <div id="s1_location_block" style="display:none;" data-level="advanced">
+                          <div class="location-toolbar" id="s1_location_toolbar" style="display:none;">
+                            <span class="location-current">目前編輯：<span id="s1_location_active_label">疼痛部位</span></span>
+                            <div class="location-switch btnbar">
+                              <button type="button" class="small" data-context="pain" onclick="switchLocationContext('pain')">編輯疼痛部位</button>
+                              <button type="button" class="small" data-context="lesion" onclick="switchLocationContext('lesion')">編輯病灶部位</button>
+                            </div>
+                            <div class="location-actions btnbar">
+                              <button type="button" class="small" id="location_copy_btn" onclick="copyLocationFromOther()">同疼痛部位</button>
+                            </div>
+                          </div>
+                          <div class="autogrid autogrid--wide">
+                            <div class="field" data-field-size="medium">
+                              <label class="h3" for="s1_location_region">部位大分類</label>
+                              <select id="s1_location_region" onchange="onSharedRegionChange()">
+                                <option value="" class="placeholder-option" disabled selected>請選擇</option>
+                                <option>頭頸部</option>
+                                <option>上肢</option>
+                                <option>軀幹</option>
+                                <option>下肢</option>
+                                <option>全身性</option>
+                              </select>
+                            </div>
+                            <div class="field" data-field-size="medium">
+                              <label class="h3" for="s1_location_subregion">細部分位</label>
+                              <select id="s1_location_subregion" onchange="onSharedSubregionChange()">
+                                <option value="" class="placeholder-option" disabled selected>請選擇</option>
+                              </select>
+                              <input id="s1_location_subregion_other" type="text" placeholder="請填寫其他部位" style="display:none; margin-top:var(--space-xs);" oninput="onSharedSubregionOtherInput()">
+                            </div>
+                            <div class="field" data-field-size="short">
+                              <label class="h3" for="s1_location_laterality">側別</label>
+                              <select id="s1_location_laterality" onchange="onSharedLateralityChange()">
+                                <option value="" class="placeholder-option" disabled selected>請選擇</option>
+                                <option>左側</option>
+                                <option>右側</option>
+                                <option>雙側</option>
+                              </select>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="medium">
+                            <label class="h3" for="s1_lesion_has">皮膚病灶【選填】</label>
+                            <select id="s1_lesion_has" onchange="toggleLesionCombined()">
+                              <option selected>無</option>
+                              <option>有</option>
+                              <option>未知</option>
+                            </select>
+                          </div>
+                          <div class="field" id="s1_lesion_layer_wrap" data-field-size="medium" style="display:none;">
+                            <label class="h3" for="s1_lesion_layer">病灶層次</label>
+                            <select id="s1_lesion_layer" onchange="toggleLesionLayerOther()">
+                              <option>無</option>
+                              <option>表皮</option>
+                              <option>皮下</option>
+                              <option>關節附近</option>
+                              <option>其他</option>
+                            </select>
+                            <input id="s1_lesion_layer_other" type="text" placeholder="請填寫" style="display:none; margin-top:var(--space-xs);">
+                          </div>
+                          <div class="field" id="s1_lesion_size_wrap" data-field-size="medium" style="display:none;">
+                            <label class="h3">病灶大小</label>
+                            <div class="lesion-size-grid">
+                              <div class="lesion-size-field">
+                                <input id="s1_lesion_length" type="number" min="0" step="0.1" placeholder="長" oninput="updateLesionAreaDisplay()">
+                                <span class="unit">cm</span>
+                              </div>
+                              <div class="lesion-size-field">
+                                <input id="s1_lesion_width" type="number" min="0" step="0.1" placeholder="寬" oninput="updateLesionAreaDisplay()">
+                                <span class="unit">cm</span>
+                              </div>
+                            </div>
+                            <div class="hint" id="s1_lesion_size_hint">請輸入長與寬，系統將即時計算面積。</div>
+                            <div class="lesion-area" id="s1_lesion_area_display">面積：— cm²</div>
+                            <div class="field-error" id="s1_lesion_size_error"></div>
+                          </div>
+                        </div>
+                        <div id="s1_lesion_more" style="display:none;" data-level="advanced">
+                          <div class="autogrid autogrid--wide">
+                            <div class="field" data-field-size="medium">
+                              <label class="h3">病灶症狀</label>
+                              <div class="lesion-mode" id="s1_lesion_mode">
+                                <button type="button" class="small" data-mode="none" onclick="setLesionSymptomMode('none')">無不適</button>
+                                <button type="button" class="small" data-mode="symptom" onclick="setLesionSymptomMode('symptom')">有症狀</button>
+                              </div>
+                              <div class="checkcol" id="s1_lesion_sx_box"></div>
+                            </div>
+                            <div class="field" data-field-size="medium">
+                              <label class="h3" for="s1_lesion_eval">醫療評估</label>
+                              <select id="s1_lesion_eval" onchange="toggleLesionHospital()">
+                                <option>未評估</option>
+                                <option>醫師評估無大礙</option>
+                                <option>已安排追蹤</option>
+                                <option>持續治療中</option>
+                              </select>
+                              <input id="s1_lesion_hospital" type="text" placeholder="醫療院所名稱" style="display:none; margin-top:var(--space-xs);">
+                            </div>
+                          </div>
+                        </div>
+                        <div class="field-error" id="s1_pain_location_error"></div>
+                      </section>
                     </div>
-                  <textarea id="section2_out" style="display:none;" data-progress-ignore="1"></textarea>
-                </div>
-            <div id="section3_block" data-section="s3">
-                  <div class="titlebar">
-                    <label class="h3 heading-tier heading-tier--primary">（三）居住環境</label>
                   </div>
+                </div>
+
+                <div class="group" id="caseProfileSummaryGroup" data-collapsed="0">
+                  <div class="group-header">
+                    <span class="h3 heading-tier heading-tier--section">總結建議</span>
+                  </div>
+                  <div class="group-content">
+                    <div class="section-card-grid">
+                      <section class="section-card" id="caseProfileActionsCard">
+                        <div class="titlebar">
+                          <span class="h5 heading-tier heading-tier--subsection">建議措施</span>
+                          <button type="button" class="small" onclick="addActionEntry()">＋新增</button>
+                        </div>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="long">
+                            <div id="s1_actions_list" class="action-list"></div>
+                            <div class="hint" id="s1_actions_hint" style="display:none;">尚未新增建議措施。</div>
+                            <div class="field-error" id="s1_actions_error"></div>
+                          </div>
+                        </div>
+                      </section>
+                      <section class="section-card" id="caseProfileNotesCard">
+                        <span class="h5 heading-tier heading-tier--subsection">補充內容</span>
+                        <div class="autogrid autogrid--wide">
+                          <div class="field" data-field-size="long">
+                            <label class="h3" for="s1_notes">補充內容【選填】</label>
+                            <textarea id="s1_notes" placeholder="其他未涵蓋重點（限簡要）；將附加於段落末端。"></textarea>
+                          </div>
+                        </div>
+                      </section>
+                    </div>
+                    <textarea id="section1_out" style="display:none;" data-progress-ignore="1"></textarea>
+                    <div id="section1_errors" class="error-messages" data-progress-ignore="1"></div>
+                    <div class="preview-toolbar" style="margin-top:var(--space-xs);">
+                      <span class="hint">預覽（主題分段）：</span>
+                      <button type="button" class="small preview-toggle" id="section1_diff_toggle" data-active="0">只看變更</button>
+                    </div>
+                    <div id="section1_rule_errors" class="error-messages" data-progress-ignore="1"></div>
+                    <div id="section1_preview_cards" class="preview-card-container" data-empty="1">
+                      <div class="preview-empty">尚未產生預覽內容。</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+        <div id="section2_block" data-section="s2">
+              <div class="titlebar">
+                <label class="h3 heading-tier heading-tier--primary">（二）經濟收入</label>
+              </div>
+                <div class="autogrid autogrid--wide">
+                  <div>
+                    <label class="h4">主要經濟來源</label>
+                    <div class="checkcol" id="s2_sources"></div>
+                  </div>
+                  <div>
                     <div class="autogrid autogrid--wide">
                       <div>
-                        <label class="h4">居住型態</label>
-                        <select id="s3_type" onchange="toggleOtherType()">
-                          <option>透天</option><option>鐵皮屋</option><option>公寓</option><option>大樓</option><option>套房</option><option>其他</option>
+                        <label class="h4">戶籍／福利身分</label>
+                        <select id="s2_id">
+                          <option>一般戶</option><option>中低收入戶</option><option>低收入戶</option>
                         </select>
-                        <input id="s3_type_other" type="text" placeholder="請輸入其他型態" style="display:none; margin-top:var(--space-xs);">
                       </div>
                       <div>
-                        <label class="h4">居住權屬</label>
-                        <select id="s3_own" onchange="toggleRentFields()"><option>自有</option><option>租賃</option><option>借住</option></select>
-                      </div>
-                      <div>
-                        <label class="h4">整潔度／異味</label>
-                        <select id="s3_clean"><option>非常整潔</option><option>整潔</option><option>尚可</option><option>需改善</option><option>髒亂</option></select>
-                      </div>
-                    </div>
-                    <div class="autogrid autogrid--wide" style="margin-top:var(--space-xs);">
-                      <div id="s3_rent_amount_wrap" style="display:none;">
-                        <label class="h5">租金金額（元/月）</label>
-                        <input id="s3_rent_amount" type="number" min="0" placeholder="例：12000">
-                      </div>
-                      <div id="s3_rent_fee_wrap" style="display:none;">
-                        <label class="h5">是否含管理費</label>
-                        <select id="s3_rent_fee">
-                          <option value="" class="placeholder-option" disabled selected>請選擇</option>
-                          <option value="含管理費">含管理費</option>
-                          <option value="不含管理費">不含管理費</option>
+                        <label class="h4">身心障礙等級</label>
+                        <select id="s2_dis_level" onchange="syncDisab()"><!-- 選擇身心障礙等級 -->
+                          <option>無</option><option>輕度</option><option>中度</option><option>重度</option><option>極重度</option>
                         </select>
                       </div>
-                      <div>
-                        <label class="h5">異味</label>
-                        <select id="s3_smell"><option>無</option><option>輕微</option><option>明顯</option></select>
-                      </div>
                     </div>
-                    <div class="autogrid autogrid--wide" style="margin-top:var(--space-xs);">
-                      <div>
-                        <label class="h4">無障礙設施</label>
-                        <div class="checkcol" id="s3_fac"></div>
-                      </div>
-                      <div>
-                        <label class="h4">輔具</label>
-                        <div class="checkcol" id="s3_aids"></div>
-                      </div>
+                    <div id="disCatBox" style="display:none; margin-top:var(--space-xs);"><!-- 類別欄位，預設隱藏 -->
+                      <label class="h4">身心障礙類別（等級≠無才需選）</label>
+                      <select id="s2_dis_cat" onchange="syncDisab()"><!-- 選擇身心障礙類別 --></select>
                     </div>
-                  <textarea id="section3_out" style="display:none;" data-progress-ignore="1"></textarea>
-                </div>
-            <div id="section4_block" data-section="s4">
-                  <div class="titlebar">
-                    <label class="h3 heading-tier heading-tier--primary">（四）社會支持</label>
                   </div>
-
-                    <div class="autogrid autogrid--wide">
-                      <div>
-                        <label class="h4">主照者關係</label>
-                        <div id="sp_primaryRel_text" class="badge">—</div>
-                      </div>
-                      <div>
-                        <label class="h4">主照者姓名</label>
-                        <div id="sp_primaryName_text" class="badge">—</div>
-                      </div>
-                      <div>
-                        <label class="h4">同住狀態</label>
-                        <select id="sp_cohabit"><option value="">—不選—</option><option>同住</option><option>不同住</option></select>
-                      </div>
-                    </div>
-
-
-                    <div class="hr"></div>
-
-                    <div class="titlebar titlebar--mt-sm">
-                      <label class="h4">主要聯繫人/決策者</label>
-                      <button type="button" class="small" onclick="copyFromH1Primary()">設為主照者</button>
-                    </div>
-                    <div class="autogrid autogrid--wide">
-                      <div class="field-intro">
-                        <label class="h4">關係</label>
-                        <select id="sp_deciderRel">
-                          <option value="">—不選—</option>
-                          <optgroup label="配偶"><option>案妻</option><option>案夫</option></optgroup>
-                          <optgroup label="子女"><option>案長子</option><option>案次子</option><option>案長女</option><option>案次女</option></optgroup>
-                          <optgroup label="父母"><option>案父</option><option>案母</option></optgroup>
-                          <optgroup label="手足"><option>案兄</option><option>案姊</option><option>案弟</option><option>案妹</option></optgroup>
-                          <optgroup label="姻親"><option>案媳</option><option>案女婿</option></optgroup>
-                          <optgroup label="孫輩"><option>案孫</option><option>案孫女</option></optgroup>
-                          <optgroup label="自訂"><option>自訂角色</option></optgroup>
-                        </select>
-                      </div>
-                      <div class="field-intro">
-                        <label class="h4">姓名</label>
-                        <input id="sp_deciderName" type="text" placeholder="請選擇">
-                      </div>
-                      <div>
-                        <label class="h4">聯絡電話</label>
-                        <input id="sp_deciderPhone" type="tel" placeholder="例如：0912-345678">
-                      </div>
-                    </div>
-
-                    <div class="hr"></div>
-
-                    <div class="titlebar titlebar--mt-sm">
-                      <label class="h4">共同照顧者（可多筆）</label>
-                      <button type="button" class="small" onclick="addCoCare()">＋新增共同照顧者</button>
-                    </div>
-                    <div id="coCare"></div>
-
-                    <div class="hr"></div>
-
-                    <div>
-                      <label class="h4">正式資源（多選）</label>
-                      <div class="muted">固定：<span class="badge">社區整合型服務中心為福安</span></div>
-                      <div class="checkcol" id="sp_formal"></div>
-                      <div id="homeCareWrap" style="display:none; margin-top:var(--space-xs);">
-                        <div class="titlebar">
-                          <label class="h4">居家服務項目（多選）</label>
-                          <button class="small" type="button" onclick="resetCareServicePhrases()">重新套用片語</button>
-                        </div>
-                        <div id="homeCareList" class="home-care-grid"></div>
-                        <div class="subtle">勾選後將自動套用至短/中期目標及長期彙整；如需記錄用量，請於右側欄位輸入數量。</div>
-                      </div>
-                      <div id="dayCareWrap" style="display:none; margin-top:var(--space-xs);">
-                        <div class="titlebar">
-                          <label class="h4">日間照顧服務項目（多選）</label>
-                          <button class="small" type="button" onclick="resetCareServicePhrases()">重新套用片語</button>
-                        </div>
-                        <div id="dayCareList" class="home-care-grid"></div>
-                        <div class="subtle">勾選後將自動套用至短/中期目標及長期彙整。</div>
-                      </div>
-                      <div id="profServiceWrap" style="display:none; margin-top:var(--space-xs);">
-                        <div class="titlebar">
-                          <label class="h4">專業服務項目（多選）</label>
-                          <button class="small" type="button" onclick="resetProfessionalPhrases()">重新套用片語</button>
-                        </div>
-                        <div id="profServiceList" class="home-care-grid"></div>
-                        <div class="subtle">勾選後將自動套用至短/中期目標及長期彙整。</div>
-                      </div>
-                      <div id="transportServiceWrap" style="display:none; margin-top:var(--space-xs);">
-                        <div class="titlebar">
-                          <label class="h4">交通接送項目（多選）</label>
-                          <button class="small" type="button" onclick="resetTransportPhrases()">重新套用片語</button>
-                        </div>
-                        <div id="transportServiceList" class="home-care-grid"></div>
-                        <div class="subtle">勾選後將自動套用至短/中期目標及長期彙整。</div>
-                      </div>
-                      <div id="respServiceWrap" style="display:none; margin-top:var(--space-xs);">
-                        <div class="titlebar">
-                          <label class="h4">喘息服務項目（多選）</label>
-                          <button class="small" type="button" onclick="resetRespitePhrases()">重新套用片語</button>
-                        </div>
-                        <div id="respServiceList" class="home-care-grid"></div>
-                        <div class="subtle">勾選後將自動套用至短/中期目標及長期彙整。</div>
-                      </div>
-                      <div id="mealServiceWrap" style="display:none; margin-top:var(--space-xs);">
-                        <div class="titlebar">
-                          <label class="h4">營養送餐項目（多選）</label>
-                          <button class="small" type="button" onclick="resetMealPhrases()">重新套用片語</button>
-                        </div>
-                        <div id="mealServiceList" class="home-care-grid"></div>
-                        <div class="subtle">勾選後將自動套用至短/中期目標及長期彙整。</div>
-                      </div>
-                    </div>
-
-                    <div class="hr"></div>
-
-                    <div>
-                      <label class="h4">非正式資源（多選，每類需填「單位名稱」）</label>
-                      <div>
-                        <label class="h5 inline"><input type="checkbox" id="sp_inf_pt" onchange="toggleInfInput('pt')"> 據點</label>
-                        <input id="sp_inf_pt_name" type="text" placeholder="單位名稱，可多個以、分隔" style="display:none;">
-                        <select id="sp_inf_pt_freq" style="display:none; margin-top:var(--space-xs);"><!-- 據點頻率 -->
-                        <option value="">—請選擇頻率—</option>
-                        <option>每週</option>
-                        <option>每月</option>
-                        <option>不定期</option>
-                        <option>未知</option>
-                      </select>
-
-                      </div>
-                      <div>
-                        <label class="h5 inline"><input type="checkbox" id="sp_inf_nb" onchange="toggleInfInput('nb')"> 鄰里</label>
-                        <input id="sp_inf_nb_name" type="text" placeholder="單位名稱，可多個以、分隔" style="display:none;">
-                        <select id="sp_inf_nb_freq" style="display:none; margin-top:var(--space-xs);"><!-- 鄰里頻率 -->
-                        <option value="">—請選擇頻率—</option>
-                        <option>每週</option>
-                        <option>每月</option>
-                        <option>不定期</option>
-                        <option>未知</option>
-                      </select>
-
-                      </div>
-                      <div>
-                        <label class="h5 inline"><input type="checkbox" id="sp_inf_rg" onchange="toggleInfInput('rg')"> 宗教社團</label>
-                        <input id="sp_inf_rg_name" type="text" placeholder="單位名稱，可多個以、分隔" style="display:none;">
-                        <select id="sp_inf_rg_freq" style="display:none; margin-top:var(--space-xs);"><!-- 宗教社團頻率 -->
-                        <option value="">—請選擇頻率—</option>
-                        <option>每週</option>
-                        <option>每月</option>
-                        <option>不定期</option>
-                        <option>未知</option>
-                      </select>
-
-                      </div>
-                      <div>
-                        <label class="h5 inline"><input type="checkbox" id="sp_inf_fw" onchange="toggleInfInput('fw')"> 財團／社會福利</label>
-                        <input id="sp_inf_fw_name" type="text" placeholder="單位名稱，可多個以、分隔" style="display:none;">
-                        <select id="sp_inf_fw_freq" style="display:none; margin-top:var(--space-xs);"><!-- 財團頻率 -->
-                        <option value="">—請選擇頻率—</option>
-                        <option>每週</option>
-                        <option>每月</option>
-                        <option>不定期</option>
-                        <option>未知</option>
-                      </select>
-
-                      </div>
-                    </div>
-
-                    <div class="hr"></div>
-                    <div>
-                      <label class="h4">高風險評估（多選）</label>
-                      <div class="checkcol" id="sp_risks"></div>
-                      <div class="subtle">勾選將只輸出「標題短語」，說明文字僅作參考。</div>
-                    </div>
-
-                  <textarea id="section4_out" style="display:none;" data-progress-ignore="1"></textarea>
                 </div>
-            <div id="section5_block" data-section="s5">
-                  <div class="titlebar">
-                    <label class="h3 heading-tier heading-tier--primary">（五）其他</label>
+              <textarea id="section2_out" style="display:none;" data-progress-ignore="1"></textarea>
+            </div>
+        <div id="section3_block" data-section="s3">
+              <div class="titlebar">
+                <label class="h3 heading-tier heading-tier--primary">（三）居住環境</label>
+              </div>
+                <div class="autogrid autogrid--wide">
+                  <div>
+                    <label class="h4">居住型態</label>
+                    <select id="s3_type" onchange="toggleOtherType()">
+                      <option>透天</option><option>鐵皮屋</option><option>公寓</option><option>大樓</option><option>套房</option><option>其他</option>
+                    </select>
+                    <input id="s3_type_other" type="text" placeholder="請輸入其他型態" style="display:none; margin-top:var(--space-xs);">
                   </div>
-                  <textarea id="section5" placeholder="如個案成長背景、職業、生活習慣、價值觀等。"></textarea>
-                </div>
-            <div id="section6_block" data-section="s6">
-                  <div class="titlebar">
-                    <label class="h3 heading-tier heading-tier--primary">（六）複評評值</label>
+                  <div>
+                    <label class="h4">居住權屬</label>
+                    <select id="s3_own" onchange="toggleRentFields()"><option>自有</option><option>租賃</option><option>借住</option></select>
                   </div>
-                  <div class="autogrid autogrid--wide">
-                    <div><label class="h4">介入前</label><textarea id="s6_before" placeholder="如果為新評，則無需輸入"></textarea></div>
-                    <div><label class="h4">介入後</label><textarea id="s6_after" placeholder="如果為新評，則無需輸入"></textarea></div>
+                  <div>
+                    <label class="h4">整潔度／異味</label>
+                    <select id="s3_clean"><option>非常整潔</option><option>整潔</option><option>尚可</option><option>需改善</option><option>髒亂</option></select>
                   </div>
-                  <textarea id="section6_struct" style="display:none;" data-progress-ignore="1"></textarea>
                 </div>
-            </section>
-
-            <!-- 五、照顧目標（原功能保留） -->
-            <section class="group card-lg span-2 plan-card-care-goals" id="careGoalsGroup" data-span="full">
-              <div class="group-header">
-                <div class="titlebar">
-                  <span class="h2">五、照顧目標</span>
+                <div class="autogrid autogrid--wide" style="margin-top:var(--space-xs);">
+                  <div id="s3_rent_amount_wrap" style="display:none;">
+                    <label class="h5">租金金額（元/月）</label>
+                    <input id="s3_rent_amount" type="number" min="0" placeholder="例：12000">
+                  </div>
+                  <div id="s3_rent_fee_wrap" style="display:none;">
+                    <label class="h5">是否含管理費</label>
+                    <select id="s3_rent_fee">
+                      <option value="" class="placeholder-option" disabled selected>請選擇</option>
+                      <option value="含管理費">含管理費</option>
+                      <option value="不含管理費">不含管理費</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label class="h5">異味</label>
+                    <select id="s3_smell"><option>無</option><option>輕微</option><option>明顯</option></select>
+                  </div>
                 </div>
+                <div class="autogrid autogrid--wide" style="margin-top:var(--space-xs);">
+                  <div>
+                    <label class="h4">無障礙設施</label>
+                    <div class="checkcol" id="s3_fac"></div>
+                  </div>
+                  <div>
+                    <label class="h4">輔具</label>
+                    <div class="checkcol" id="s3_aids"></div>
+                  </div>
+                </div>
+              <textarea id="section3_out" style="display:none;" data-progress-ignore="1"></textarea>
+            </div>
+        <div id="section4_block" data-section="s4">
+              <div class="titlebar">
+                <label class="h3 heading-tier heading-tier--primary">（四）社會支持</label>
               </div>
 
-              <div class="group-content">
-                <div id="careGoals_block" data-section="cg">
-                  <div class="titlebar">
-                    <label class="h3 heading-tier heading-tier--primary">（一）照顧問題（最多選 5 項）</label>
+                <div class="autogrid autogrid--wide">
+                  <div>
+                    <label class="h4">主照者關係</label>
+                    <div id="sp_primaryRel_text" class="badge">—</div>
                   </div>
-                  <div class="care-goal-block">
-                    <div class="care-goal-heading">
-                      <div id="problemCount">已選 0 / 5</div>
-                    </div>
-                    <div class="checkcol" id="problemList"></div>
-                    <div class="virtual-checklist-print" id="problemListPrint" aria-hidden="true"></div>
-                    <label class="h4" style="margin-top:var(--space-xs);">補充說明（可選）</label>
-                    <textarea id="problemNote" placeholder="例如：近期以移位與吞嚥為優先風險…"></textarea>
+                  <div>
+                    <label class="h4">主照者姓名</label>
+                    <div id="sp_primaryName_text" class="badge">—</div>
                   </div>
-
-                  <div class="titlebar">
-                    <label class="h3 heading-tier heading-tier--primary">（二）短期目標（0–3 個月）</label>
-                  </div>
-                  <div class="care-goal-block">
-                    <div class="autogrid autogrid--wide">
-                      <div id="short_care_wrap"><label class="h4">照顧服務</label><textarea id="short_care" placeholder="填寫欄位"></textarea></div>
-                      <div id="short_prof_wrap"><label class="h4">專業服務</label><textarea id="short_prof" placeholder="填寫欄位"></textarea></div>
-                      <div id="short_car_wrap"><label class="h4">交通接送</label><textarea id="short_car"  placeholder="填寫欄位"></textarea></div>
-                      <div id="short_resp_wrap"><label class="h4">喘息服務</label><textarea id="short_resp" placeholder="填寫欄位"></textarea></div>
-                      <div id="short_access_wrap"><label class="h4">無障礙及輔具</label><textarea id="short_access" placeholder="填寫欄位"></textarea></div>
-                      <div id="short_meal_wrap"><label class="h4">營養送餐</label><textarea id="short_meal" placeholder="填寫欄位"></textarea></div>
-                    </div>
-                  </div>
-
-                  <div class="titlebar">
-                    <label class="h3 heading-tier heading-tier--primary">（三）中期目標（3–4 個月）</label>
-                  </div>
-                  <div class="care-goal-block">
-                    <div class="autogrid autogrid--wide">
-                      <div id="mid_care_wrap"><label class="h4">照顧服務</label><textarea id="mid_care" placeholder="填寫欄位"></textarea></div>
-                      <div id="mid_prof_wrap"><label class="h4">專業服務</label><textarea id="mid_prof" placeholder="填寫欄位"></textarea></div>
-                      <div id="mid_car_wrap"><label class="h4">交通接送</label><textarea id="mid_car"  placeholder="填寫欄位"></textarea></div>
-                      <div id="mid_resp_wrap"><label class="h4">喘息服務</label><textarea id="mid_resp" placeholder="填寫欄位"></textarea></div>
-                      <div id="mid_access_wrap"><label class="h4">無障礙及輔具</label><textarea id="mid_access" placeholder="填寫欄位"></textarea></div>
-                      <div id="mid_meal_wrap"><label class="h4">營養送餐</label><textarea id="mid_meal" placeholder="填寫欄位"></textarea></div>
-                    </div>
-                  </div>
-
-                  <div class="titlebar">
-                    <label class="h3 heading-tier heading-tier--primary">（四）長期目標（4–6 個月）</label>
-                  </div>
-                  <div class="care-goals-side-inner">
-                    <textarea id="long_goal" placeholder="將由短/中期彙整自動填入；可再微調。"></textarea>
-                    <div class="hr"></div>
-                    <label class="h4">目標文字預覽（含碼別與各期結構）</label>
-                    <div id="goalPreview" class="preview goal-preview-empty">（尚未選擇服務或填寫內容）</div>
+                  <div>
+                    <label class="h4">同住狀態</label>
+                    <select id="sp_cohabit"><option value="">—不選—</option><option>同住</option><option>不同住</option></select>
                   </div>
                 </div>
-              </div>
-            </section>
 
-            <!-- 六、與照專…（原功能保留） -->
-            <section class="group card-lg span-2 plan-card-mismatch" id="mismatchPlanGroup" data-span="full">
-              <div class="group-header">
-                <div class="titlebar">
-                  <span class="h2">六、與照專建議服務項目、問題清單不一致原因說明及未來規劃、後續追蹤計劃</span>
+
+                <div class="hr"></div>
+
+                <div class="titlebar titlebar--mt-sm">
+                  <label class="h4">主要聯繫人/決策者</label>
+                  <button type="button" class="small" onclick="copyFromH1Primary()">設為主照者</button>
                 </div>
+                <div class="autogrid autogrid--wide">
+                  <div class="field-intro">
+                    <label class="h4">關係</label>
+                    <select id="sp_deciderRel">
+                      <option value="">—不選—</option>
+                      <optgroup label="配偶"><option>案妻</option><option>案夫</option></optgroup>
+                      <optgroup label="子女"><option>案長子</option><option>案次子</option><option>案長女</option><option>案次女</option></optgroup>
+                      <optgroup label="父母"><option>案父</option><option>案母</option></optgroup>
+                      <optgroup label="手足"><option>案兄</option><option>案姊</option><option>案弟</option><option>案妹</option></optgroup>
+                      <optgroup label="姻親"><option>案媳</option><option>案女婿</option></optgroup>
+                      <optgroup label="孫輩"><option>案孫</option><option>案孫女</option></optgroup>
+                      <optgroup label="自訂"><option>自訂角色</option></optgroup>
+                    </select>
+                  </div>
+                  <div class="field-intro">
+                    <label class="h4">姓名</label>
+                    <input id="sp_deciderName" type="text" placeholder="請選擇">
+                  </div>
+                  <div>
+                    <label class="h4">聯絡電話</label>
+                    <input id="sp_deciderPhone" type="tel" placeholder="例如：0912-345678">
+                  </div>
+                </div>
+
+                <div class="hr"></div>
+
+                <div class="titlebar titlebar--mt-sm">
+                  <label class="h4">共同照顧者（可多筆）</label>
+                  <button type="button" class="small" onclick="addCoCare()">＋新增共同照顧者</button>
+                </div>
+                <div id="coCare"></div>
+
+                <div class="hr"></div>
+
+                <div>
+                  <label class="h4">正式資源（多選）</label>
+                  <div class="muted">固定：<span class="badge">社區整合型服務中心為福安</span></div>
+                  <div class="checkcol" id="sp_formal"></div>
+                  <div id="homeCareWrap" style="display:none; margin-top:var(--space-xs);">
+                    <div class="titlebar">
+                      <label class="h4">居家服務項目（多選）</label>
+                      <button class="small" type="button" onclick="resetCareServicePhrases()">重新套用片語</button>
+                    </div>
+                    <div id="homeCareList" class="home-care-grid"></div>
+                    <div class="subtle">勾選後將自動套用至短/中期目標及長期彙整；如需記錄用量，請於右側欄位輸入數量。</div>
+                  </div>
+                  <div id="dayCareWrap" style="display:none; margin-top:var(--space-xs);">
+                    <div class="titlebar">
+                      <label class="h4">日間照顧服務項目（多選）</label>
+                      <button class="small" type="button" onclick="resetCareServicePhrases()">重新套用片語</button>
+                    </div>
+                    <div id="dayCareList" class="home-care-grid"></div>
+                    <div class="subtle">勾選後將自動套用至短/中期目標及長期彙整。</div>
+                  </div>
+                  <div id="profServiceWrap" style="display:none; margin-top:var(--space-xs);">
+                    <div class="titlebar">
+                      <label class="h4">專業服務項目（多選）</label>
+                      <button class="small" type="button" onclick="resetProfessionalPhrases()">重新套用片語</button>
+                    </div>
+                    <div id="profServiceList" class="home-care-grid"></div>
+                    <div class="subtle">勾選後將自動套用至短/中期目標及長期彙整。</div>
+                  </div>
+                  <div id="transportServiceWrap" style="display:none; margin-top:var(--space-xs);">
+                    <div class="titlebar">
+                      <label class="h4">交通接送項目（多選）</label>
+                      <button class="small" type="button" onclick="resetTransportPhrases()">重新套用片語</button>
+                    </div>
+                    <div id="transportServiceList" class="home-care-grid"></div>
+                    <div class="subtle">勾選後將自動套用至短/中期目標及長期彙整。</div>
+                  </div>
+                  <div id="respServiceWrap" style="display:none; margin-top:var(--space-xs);">
+                    <div class="titlebar">
+                      <label class="h4">喘息服務項目（多選）</label>
+                      <button class="small" type="button" onclick="resetRespitePhrases()">重新套用片語</button>
+                    </div>
+                    <div id="respServiceList" class="home-care-grid"></div>
+                    <div class="subtle">勾選後將自動套用至短/中期目標及長期彙整。</div>
+                  </div>
+                  <div id="mealServiceWrap" style="display:none; margin-top:var(--space-xs);">
+                    <div class="titlebar">
+                      <label class="h4">營養送餐項目（多選）</label>
+                      <button class="small" type="button" onclick="resetMealPhrases()">重新套用片語</button>
+                    </div>
+                    <div id="mealServiceList" class="home-care-grid"></div>
+                    <div class="subtle">勾選後將自動套用至短/中期目標及長期彙整。</div>
+                  </div>
+                </div>
+
+                <div class="hr"></div>
+
+                <div>
+                  <label class="h4">非正式資源（多選，每類需填「單位名稱」）</label>
+                  <div>
+                    <label class="h5 inline"><input type="checkbox" id="sp_inf_pt" onchange="toggleInfInput('pt')"> 據點</label>
+                    <input id="sp_inf_pt_name" type="text" placeholder="單位名稱，可多個以、分隔" style="display:none;">
+                    <select id="sp_inf_pt_freq" style="display:none; margin-top:var(--space-xs);"><!-- 據點頻率 -->
+                    <option value="">—請選擇頻率—</option>
+                    <option>每週</option>
+                    <option>每月</option>
+                    <option>不定期</option>
+                    <option>未知</option>
+                  </select>
+
+                  </div>
+                  <div>
+                    <label class="h5 inline"><input type="checkbox" id="sp_inf_nb" onchange="toggleInfInput('nb')"> 鄰里</label>
+                    <input id="sp_inf_nb_name" type="text" placeholder="單位名稱，可多個以、分隔" style="display:none;">
+                    <select id="sp_inf_nb_freq" style="display:none; margin-top:var(--space-xs);"><!-- 鄰里頻率 -->
+                    <option value="">—請選擇頻率—</option>
+                    <option>每週</option>
+                    <option>每月</option>
+                    <option>不定期</option>
+                    <option>未知</option>
+                  </select>
+
+                  </div>
+                  <div>
+                    <label class="h5 inline"><input type="checkbox" id="sp_inf_rg" onchange="toggleInfInput('rg')"> 宗教社團</label>
+                    <input id="sp_inf_rg_name" type="text" placeholder="單位名稱，可多個以、分隔" style="display:none;">
+                    <select id="sp_inf_rg_freq" style="display:none; margin-top:var(--space-xs);"><!-- 宗教社團頻率 -->
+                    <option value="">—請選擇頻率—</option>
+                    <option>每週</option>
+                    <option>每月</option>
+                    <option>不定期</option>
+                    <option>未知</option>
+                  </select>
+
+                  </div>
+                  <div>
+                    <label class="h5 inline"><input type="checkbox" id="sp_inf_fw" onchange="toggleInfInput('fw')"> 財團／社會福利</label>
+                    <input id="sp_inf_fw_name" type="text" placeholder="單位名稱，可多個以、分隔" style="display:none;">
+                    <select id="sp_inf_fw_freq" style="display:none; margin-top:var(--space-xs);"><!-- 財團頻率 -->
+                    <option value="">—請選擇頻率—</option>
+                    <option>每週</option>
+                    <option>每月</option>
+                    <option>不定期</option>
+                    <option>未知</option>
+                  </select>
+
+                  </div>
+                </div>
+
+                <div class="hr"></div>
+                <div>
+                  <label class="h4">高風險評估（多選）</label>
+                  <div class="checkcol" id="sp_risks"></div>
+                  <div class="subtle">勾選將只輸出「標題短語」，說明文字僅作參考。</div>
+                </div>
+
+              <textarea id="section4_out" style="display:none;" data-progress-ignore="1"></textarea>
+            </div>
+        <div id="section5_block" data-section="s5">
+              <div class="titlebar">
+                <label class="h3 heading-tier heading-tier--primary">（五）其他</label>
               </div>
-              <div class="group-content">
-                <div class="row"><div>
-                  <label class="h3">（一）目標達成的狀況以及未達成的差距</label>
-                  <textarea id="reason1" placeholder="填寫欄位"></textarea>
-                </div></div>
-                <div class="row"><div>
-                  <label class="h3">（二）資源的變動情形</label>
-                  <textarea id="reason2" placeholder="填寫欄位"></textarea>
-                </div></div>
-                <div class="row"><div>
-                  <label class="h3">（三）未使用的替代方案或是可能的影響</label>
-                  <textarea id="reason3" placeholder="填寫欄位"></textarea>
-                  <div class="hr"></div>
-                  <label class="h4">常用快捷（勾選即加入第 3 格）</label>
-                  <div style="margin:var(--space-xs) 0;">
-                    <input id="rq1_no" type="text" placeholder="原服務，例如：備餐" style="margin-right:4px;">
-                    <input id="rq1_alt" type="text" placeholder="替代服務，例如：代購服務">
-                  </div>
-                  <label class="h5 inline"><input type="checkbox" id="rq1"> 1.經與<span id="rq1_who">案○</span>討論，目前暫無<span id="rq1_no_preview" data-def="備餐">備餐</span>之需求，改為<span id="rq1_alt_preview" data-def="代購服務">代購服務</span>。</label>
-                  <div style="margin:var(--space-xs) 0;">
-                    <input id="rq2_service" type="text" placeholder="服務，例如：專業服務">
-                  </div>
-                  <label class="h5 inline"><input type="checkbox" id="rq2"> 2.經與<span id="rq2_who">案○</span>討論，目前因個案身體狀況，暫無<span id="rq2_service_preview" data-def="專業服務">專業服務</span>需求，日後待個案狀況好轉後，依當下狀況核定，續追蹤。</label>
-                  <div id="mismatch_diff_block" style="display:none; margin-top:var(--space-sm);">
-                    <div class="hint" id="mismatch_diff_text">與照專建議服務不一致項目：</div>
-                    <div class="mismatch-diff" id="mismatch_diff_list"></div>
-                    <div class="checkcol" id="mismatch_reason_box" data-legend="與照專建議服務不一致項目"></div>
-                    <input id="mismatch_reason_other" type="text" placeholder="請說明其他原因" style="display:none; margin-top:var(--space-xs);">
-                    <div class="field-error" id="mismatch_reason_error"></div>
-                  </div>
-                </div></div>
+              <textarea id="section5" placeholder="如個案成長背景、職業、生活習慣、價值觀等。"></textarea>
+            </div>
+        <div id="section6_block" data-section="s6">
+              <div class="titlebar">
+                <label class="h3 heading-tier heading-tier--primary">（六）複評評值</label>
               </div>
-            </section>
+              <div class="autogrid autogrid--wide">
+                <div><label class="h4">介入前</label><textarea id="s6_before" placeholder="如果為新評，則無需輸入"></textarea></div>
+                <div><label class="h4">介入後</label><textarea id="s6_after" placeholder="如果為新評，則無需輸入"></textarea></div>
+              </div>
+              <textarea id="section6_struct" style="display:none;" data-progress-ignore="1"></textarea>
+            </div>
+    </div>
+
+
+        <!-- 五、照顧目標（原功能保留） -->
+        <div class="group card-lg span-2 plan-card-care-goals" id="careGoalsGroup" data-span="full">
+          <div class="group-header">
+            <div class="titlebar">
+              <span class="h2">五、照顧目標</span>
+            </div>
           </div>
-        </section>
+
+          <div class="group-content">
+            <div id="careGoals_block" data-section="cg">
+              <div class="titlebar">
+                <label class="h3 heading-tier heading-tier--primary">（一）照顧問題（最多選 5 項）</label>
+              </div>
+              <div class="care-goal-block">
+                <div class="care-goal-heading">
+                  <div id="problemCount">已選 0 / 5</div>
+                </div>
+                <div class="checkcol" id="problemList"></div>
+                <div class="virtual-checklist-print" id="problemListPrint" aria-hidden="true"></div>
+                <label class="h4" style="margin-top:var(--space-xs);">補充說明（可選）</label>
+                <textarea id="problemNote" placeholder="例如：近期以移位與吞嚥為優先風險…"></textarea>
+              </div>
+
+              <div class="titlebar">
+                <label class="h3 heading-tier heading-tier--primary">（二）短期目標（0–3 個月）</label>
+              </div>
+              <div class="care-goal-block">
+                <div class="autogrid autogrid--wide">
+                  <div id="short_care_wrap"><label class="h4">照顧服務</label><textarea id="short_care" placeholder="填寫欄位"></textarea></div>
+                  <div id="short_prof_wrap"><label class="h4">專業服務</label><textarea id="short_prof" placeholder="填寫欄位"></textarea></div>
+                  <div id="short_car_wrap"><label class="h4">交通接送</label><textarea id="short_car"  placeholder="填寫欄位"></textarea></div>
+                  <div id="short_resp_wrap"><label class="h4">喘息服務</label><textarea id="short_resp" placeholder="填寫欄位"></textarea></div>
+                  <div id="short_access_wrap"><label class="h4">無障礙及輔具</label><textarea id="short_access" placeholder="填寫欄位"></textarea></div>
+                  <div id="short_meal_wrap"><label class="h4">營養送餐</label><textarea id="short_meal" placeholder="填寫欄位"></textarea></div>
+                </div>
+              </div>
+
+              <div class="titlebar">
+                <label class="h3 heading-tier heading-tier--primary">（三）中期目標（3–4 個月）</label>
+              </div>
+              <div class="care-goal-block">
+                <div class="autogrid autogrid--wide">
+                  <div id="mid_care_wrap"><label class="h4">照顧服務</label><textarea id="mid_care" placeholder="填寫欄位"></textarea></div>
+                  <div id="mid_prof_wrap"><label class="h4">專業服務</label><textarea id="mid_prof" placeholder="填寫欄位"></textarea></div>
+                  <div id="mid_car_wrap"><label class="h4">交通接送</label><textarea id="mid_car"  placeholder="填寫欄位"></textarea></div>
+                  <div id="mid_resp_wrap"><label class="h4">喘息服務</label><textarea id="mid_resp" placeholder="填寫欄位"></textarea></div>
+                  <div id="mid_access_wrap"><label class="h4">無障礙及輔具</label><textarea id="mid_access" placeholder="填寫欄位"></textarea></div>
+                  <div id="mid_meal_wrap"><label class="h4">營養送餐</label><textarea id="mid_meal" placeholder="填寫欄位"></textarea></div>
+                </div>
+              </div>
+
+              <div class="titlebar">
+                <label class="h3 heading-tier heading-tier--primary">（四）長期目標（4–6 個月）</label>
+              </div>
+              <div class="care-goals-side-inner">
+                <textarea id="long_goal" placeholder="將由短/中期彙整自動填入；可再微調。"></textarea>
+                <div class="hr"></div>
+                <label class="h4">目標文字預覽（含碼別與各期結構）</label>
+                <div id="goalPreview" class="preview goal-preview-empty">（尚未選擇服務或填寫內容）</div>
+              </div>
+            </div>
+          </div>
+    </div>
+
+
+        <!-- 六、與照專…（原功能保留） -->
+        <div class="group card-lg span-2 plan-card-mismatch" id="mismatchPlanGroup" data-span="full">
+          <div class="group-header">
+            <div class="titlebar">
+              <span class="h2">六、與照專建議服務項目、問題清單不一致原因說明及未來規劃、後續追蹤計劃</span>
+            </div>
+          </div>
+          <div class="group-content">
+            <div class="row"><div>
+              <label class="h3">（一）目標達成的狀況以及未達成的差距</label>
+              <textarea id="reason1" placeholder="填寫欄位"></textarea>
+            </div></div>
+            <div class="row"><div>
+              <label class="h3">（二）資源的變動情形</label>
+              <textarea id="reason2" placeholder="填寫欄位"></textarea>
+            </div></div>
+            <div class="row"><div>
+              <label class="h3">（三）未使用的替代方案或是可能的影響</label>
+              <textarea id="reason3" placeholder="填寫欄位"></textarea>
+              <div class="hr"></div>
+              <label class="h4">常用快捷（勾選即加入第 3 格）</label>
+              <div style="margin:var(--space-xs) 0;">
+                <input id="rq1_no" type="text" placeholder="原服務，例如：備餐" style="margin-right:4px;">
+                <input id="rq1_alt" type="text" placeholder="替代服務，例如：代購服務">
+              </div>
+              <label class="h5 inline"><input type="checkbox" id="rq1"> 1.經與<span id="rq1_who">案○</span>討論，目前暫無<span id="rq1_no_preview" data-def="備餐">備餐</span>之需求，改為<span id="rq1_alt_preview" data-def="代購服務">代購服務</span>。</label>
+              <div style="margin:var(--space-xs) 0;">
+                <input id="rq2_service" type="text" placeholder="服務，例如：專業服務">
+              </div>
+              <label class="h5 inline"><input type="checkbox" id="rq2"> 2.經與<span id="rq2_who">案○</span>討論，目前因個案身體狀況，暫無<span id="rq2_service_preview" data-def="專業服務">專業服務</span>需求，日後待個案狀況好轉後，依當下狀況核定，續追蹤。</label>
+              <div id="mismatch_diff_block" style="display:none; margin-top:var(--space-sm);">
+                <div class="hint" id="mismatch_diff_text">與照專建議服務不一致項目：</div>
+                <div class="mismatch-diff" id="mismatch_diff_list"></div>
+                <div class="checkcol" id="mismatch_reason_box" data-legend="與照專建議服務不一致項目"></div>
+                <input id="mismatch_reason_other" type="text" placeholder="請說明其他原因" style="display:none; margin-top:var(--space-xs);">
+                <div class="field-error" id="mismatch_reason_error"></div>
+              </div>
+            </div></div>
+          </div>
+    </div>
+
   </div>
 
   <div class="page-section" data-page="execution" data-columns="2">
@@ -4206,7 +4211,7 @@
       </div>
       <div class="group-content">
         <div class="section-card-grid">
-        <section class="section-card" id="planExecutionGroup">
+        <section class="section-card" id="planExecutionCard">
           <div class="titlebar">
             <label class="h2">一、長照服務核定項目、頻率</label>
           </div>
@@ -4226,7 +4231,7 @@
           </div>
         </section>
 
-        <section class="section-card" id="planReferralSection">
+        <section class="section-card" id="planReferralCard">
           <div class="titlebar">
             <label class="h2">二、轉介其他服務資源</label>
           </div>
@@ -4247,7 +4252,7 @@
           </div>
         </section>
 
-        <section class="section-card" id="planSummaryGroup">
+        <section class="section-card" id="planSummaryCard">
           <div class="titlebar">
             <label class="h2">附件二（服務計畫明細）預覽</label>
           </div>
@@ -4289,7 +4294,7 @@
           </div>
         </section>
 
-        <section class="section-card" id="planTextGroup">
+        <section class="section-card" id="planExecutionPreviewCard">
           <div class="titlebar">
             <label class="h2">附件一：計畫執行規劃預覽</label>
           </div>
@@ -4957,7 +4962,7 @@
       const configs = [
         { pageId:'basic', anchorIds:['basicInfoGroup'], preferredRoot:appContainer },
         { pageId:'goals', anchorIds:['contactVisitGroup'], preferredRoot:appContainer, dedupeIds:['contactVisitGroup'] },
-        { pageId:'execution', anchorIds:['planExecutionGroup','planSummaryGroup','planTextGroup'], preferredRoot:appContainer },
+        { pageId:'execution', anchorIds:['planExecutionCard','planSummaryCard','planExecutionPreviewCard'], preferredRoot:appContainer },
         { pageId:'notes', anchorIds:['planOtherGroup'], preferredRoot:appContainer }
       ];
       configs.forEach(cfg=>dedupePageSection(cfg.pageId, cfg));
@@ -5413,9 +5418,9 @@
       'h2-goals-homevisit': { selector:'#contactVisitGroup .contact-visit-card[data-card="visit"] .titlebar .h2', mode:'replace', className:'h2' },
       'h3-goals-homevisit-date': { selector:'#contactVisitGroup label[for="visitDate"]', mode:'labelHeading', className:'h3' },
       'h3-goals-prep-date': { selector:'#dischargeBox label[for="dischargeDate"]', mode:'labelHeading', className:'h3', label:'出院日期' },
-      'h2-goals-companions': { selector:'#visitPartnersGroup .titlebar .h2', mode:'replace', className:'h2' },
-      'h3-goals-primary-rel': { selector:'#visitPartnersGroup label[for="primaryRel"]', mode:'labelHeading', className:'h3' },
-      'h3-goals-primary-name': { selector:'#visitPartnersGroup label[for="primaryName"]', mode:'labelHeading', className:'h3' },
+      'h2-goals-companions': { selector:'#visitPartnersCard .titlebar .h2', mode:'replace', className:'h2' },
+      'h3-goals-primary-rel': { selector:'#visitPartnersCard label[for="primaryRel"]', mode:'labelHeading', className:'h3' },
+      'h3-goals-primary-name': { selector:'#visitPartnersCard label[for="primaryName"]', mode:'labelHeading', className:'h3' },
       'h2-goals-overview': { selector:'#caseOverviewGroup .titlebar .h2', mode:'replace', className:'h2 heading-tier heading-tier--primary' },
       'h3-goals-s1': { selector:'#section1_block > .titlebar label', mode:'replace', className:'h3 heading-tier heading-tier--primary' },
       'h3-goals-s2': { selector:'#section2_block > .titlebar label', mode:'replace', className:'h3 heading-tier heading-tier--primary' },
@@ -5433,7 +5438,7 @@
       'h3-goals-mismatch-2': { selector:'#mismatchPlanGroup textarea#reason2', mode:'previousLabelHeading', className:'h3' },
       'h3-goals-mismatch-3': { selector:'#mismatchPlanGroup textarea#reason3', mode:'previousLabelHeading', className:'h3' },
       'h1-exec': { selector:'.page-section[data-page="execution"] .group > .group-header .titlebar .h1', mode:'replace', className:'h1' },
-      'h2-exec-services': { selector:'#planExecutionGroup .titlebar label', mode:'replace', className:'h2' },
+      'h2-exec-services': { selector:'#planExecutionCard .titlebar label', mode:'replace', className:'h2' },
       'h3-exec-b': { selector:'#planEditor .plan-category[data-plan-category="B"] .plan-category-heading h3', mode:'replace', className:'h3' },
       'h3-exec-c': { selector:'#planEditor .plan-category[data-plan-category="C"] .plan-category-heading h3', mode:'replace', className:'h3' },
       'h3-exec-d': { selector:'#planEditor .plan-category[data-plan-category="D"] .plan-category-heading h3', mode:'replace', className:'h3' },
@@ -5441,8 +5446,8 @@
       'h3-exec-g': { selector:'#planEditor .plan-category[data-plan-category="G"] .plan-category-heading h3', mode:'replace', className:'h3' },
       'h3-exec-sc': { selector:'#planEditor .plan-category[data-plan-category="SC"] .plan-category-heading h3', mode:'replace', className:'h3' },
       'h3-exec-nutrition': { selector:'#planEditor .plan-category[data-plan-category="MEAL"] .plan-category-heading h3', mode:'replace', className:'h3' },
-      'h3-exec-emergency': { selector:'#planExecutionGroup .plan-category[data-plan-category="EMERGENCY"] .plan-category-heading h3', mode:'replace', className:'h3' },
-      'h2-exec-referral': { selector:'#planReferralSection .titlebar label', mode:'replace', className:'h2' },
+      'h3-exec-emergency': { selector:'#planExecutionCard .plan-category[data-plan-category="EMERGENCY"] .plan-category-heading h3', mode:'replace', className:'h3' },
+      'h2-exec-referral': { selector:'#planReferralCard .titlebar label', mode:'replace', className:'h2' },
       'h1-notes': { selector:'#planOtherGroup .titlebar .h1', mode:'replace', className:'h1' },
       'h2-notes-other': { selector:'#planOtherGroup .section-card .titlebar .h2, #planOtherGroup .section-card .titlebar span.h2', mode:'replace', className:'h2' }
     });
@@ -8497,7 +8502,7 @@
     }
     function updateParticipantConflictHint(){
       const box=document.getElementById('extras_conflict');
-      const group=document.getElementById('visitPartnersGroup');
+      const group=document.getElementById('visitPartnersCard');
       if(!box){
         if(group) group.dataset.conflict='0';
         return {hasConflict:false, roles:[]};


### PR DESCRIPTION
## Summary
- refactor the basic and goals page sections so each section card is nested under a group content grid and page sections stay as siblings
- move the case overview, care goals, and mismatch blocks out of the contact cards grid and keep them as dedicated groups
- rename execution preview card ids and related styles/scripts to avoid duplicate ids

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d42e722684832baf8f604a7fa62deb