### PR TITLE
fix: patch heading spec and dom targets

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -4407,7 +4407,7 @@
     const HEADING_SPEC_VERSION = '2024-04-01';
     const HEADING_SPEC_VERSION_STORAGE_KEY = 'AA01.headingSpec.version';
 
-    const HEADING_SPEC = Object.freeze([
+    const HEADING_SPEC = [
       {
         id:'h1-basic', tag:'h1', label:'基本資訊', page:'basic',
         children:[
@@ -4498,34 +4498,230 @@
           { id:'h2-notes-other', tag:'h2', label:'其他(個案特殊狀況或其他未盡事宜可備註於此)' }
         ]
       }
-    ]);
+    ];
 
-    const HEADING_INDEX = (function(){
-      const index = {};
-      let order = 0;
-      function assign(entries, parent){
-        if(!Array.isArray(entries)) return;
-        entries.forEach(entry=>{
-          if(!entry || !entry.id) return;
-          const node = {
-            id:entry.id,
-            label:entry.label || '',
-            tag:entry.tag || (parent ? parent.tag : 'h1'),
-            level:entry.tag ? Number(entry.tag.replace(/[^0-9]/g,'')) || (parent ? parent.level + 1 : 1) : (parent ? parent.level + 1 : 1),
-            page:entry.page || (parent ? parent.page : ''),
-            parentId:parent ? parent.id : null,
-            order:order++,
-            children:Array.isArray(entry.children) ? entry.children.map(child=>child.id) : []
-          };
-          index[node.id] = node;
-          if(Array.isArray(entry.children) && entry.children.length){
-            assign(entry.children, node);
-          }
-        });
+    // === 標題權威清單（只列 H1～H3；H4/H5 由各卡內小標自行管理）===
+    const EXPECTED_HEADINGS = [
+      // H1
+      { id:'h1-basic', tag:'h1', label:'基本資訊' },
+      { id:'h1-goals', tag:'h1', label:'計畫目標' },
+      { id:'h1-exec',  tag:'h1', label:'計畫執行規劃' },
+      { id:'h1-notes', tag:'h1', label:'其他備註' },
+
+      // H2 under H1 基本資訊
+      { id:'h2-basic-unit-code',     tag:'h2', label:'單位代碼' },
+      { id:'h2-basic-case-manager',  tag:'h2', label:'個案管理師' },
+      { id:'h2-basic-case-name',     tag:'h2', label:'個案姓名' },
+      { id:'h2-basic-consultant-name', tag:'h2', label:'照專姓名' },
+      { id:'h2-basic-cms-level',     tag:'h2', label:'CMS 等級' },
+
+      // H2 under H1 計畫目標
+      { id:'h2-goals-call',          tag:'h2', label:'一、電聯日期' },
+      { id:'h2-goals-homevisit',     tag:'h2', label:'二、家訪日期' },
+      { id:'h2-goals-companions',    tag:'h2', label:'三、偕同訪視者' },
+      { id:'h2-goals-overview',      tag:'h2', label:'四、個案概況' },
+      { id:'h2-goals-targets',       tag:'h2', label:'五、照顧目標' },
+      { id:'h2-goals-mismatch',      tag:'h2', label:'六、不一致原因說明' },
+
+      // H3 under H2 一、電聯日期
+      { id:'h3-goals-call-date',     tag:'h3', label:'電聯日期' },
+      { id:'h3-goals-call-consult',  tag:'h3', label:'照顧專員約訪' }, // ★此次新增
+
+      // H3 under H2 二、家訪日期
+      { id:'h3-goals-homevisit-date', tag:'h3', label:'家訪日期' },
+      { id:'h3-goals-prep-date',      tag:'h3', label:'出院日期' },
+
+      // H3 under H2 三、偕同訪視者
+      { id:'h3-goals-primary-rel',  tag:'h3', label:'主要照顧者關係' },
+      { id:'h3-goals-primary-name', tag:'h3', label:'主要照顧者姓名' },
+      { id:'h3-goals-extra-rel',    tag:'h3', label:'其他參與者關係' },
+      { id:'h3-goals-extra-name',   tag:'h3', label:'其他參與者姓名' },
+
+      // H3 under H2 四、個案概況（只至 H3 節點）
+      { id:'h3-goals-s1', tag:'h3', label:'（一）身心概況' },
+      { id:'h3-goals-s2', tag:'h3', label:'（二）經濟收入' },
+      { id:'h3-goals-s3', tag:'h3', label:'（三）居住環境' },
+      { id:'h3-goals-s4', tag:'h3', label:'（四）社會支持' },
+      { id:'h3-goals-s5', tag:'h3', label:'（五）其他' },
+      { id:'h3-goals-s6', tag:'h3', label:'（六）複評評值' },
+
+      // H3 under H2 五、照顧目標
+      { id:'h3-goals-targets-problems', tag:'h3', label:'（一）照顧問題' },
+      { id:'h3-goals-targets-short',    tag:'h3', label:'（二）短期目標（0–3 個月）' },
+      { id:'h3-goals-targets-mid',      tag:'h3', label:'（三）中期目標（3–4 個月）' },
+      { id:'h3-goals-targets-long',     tag:'h3', label:'（四）長期目標（4–6 個月）' },
+
+      // H3 under H2 六、不一致原因說明
+      { id:'h3-goals-mismatch-1', tag:'h3', label:'（一）目標達成狀況及差距' },
+      { id:'h3-goals-mismatch-2', tag:'h3', label:'（二）資源變動情形' },
+      { id:'h3-goals-mismatch-3', tag:'h3', label:'（三）未使用的替代方案／影響' },
+
+      // H2 under H1 計畫執行規劃（此區僅 H2）
+      { id:'h2-exec-services',     tag:'h2', label:'一、長照服務核定項目、頻率' },
+      { id:'h2-exec-referral',     tag:'h2', label:'二、轉介其他服務資源' },
+      { id:'h2-exec-station',      tag:'h2', label:'三、巷弄長照站資訊與意願' },
+      { id:'h2-exec-emergency-note', tag:'h2', label:'四、緊急救援服務說明' },
+      { id:'h2-exec-attachment2',  tag:'h2', label:'附件二（服務計畫明細）預覽' },
+      { id:'h2-exec-attachment1',  tag:'h2', label:'附件一（計畫執行規劃預覽）' },
+
+      // H2 under H1 其他備註（此區僅 H2）
+      { id:'h2-notes-other', tag:'h2', label:'其他（個案特殊狀況或其他未盡事宜）' }
+    ];
+
+    function collectExistingHeadingIds(entries, collector){
+      if(!Array.isArray(entries)) return;
+      for(var i=0; i<entries.length; i++){
+        var entry = entries[i];
+        if(!entry || !entry.id) continue;
+        collector.add(entry.id);
+        if(Array.isArray(entry.children) && entry.children.length){
+          collectExistingHeadingIds(entry.children, collector);
+        }
       }
-      assign(HEADING_SPEC, null);
-      return index;
-    })();
+    }
+
+    function findHeadingSpecNodeById(entries, id){
+      if(!Array.isArray(entries)) return null;
+      for(var i=0; i<entries.length; i++){
+        var entry = entries[i];
+        if(!entry || !entry.id) continue;
+        if(entry.id === id) return entry;
+        if(Array.isArray(entry.children) && entry.children.length){
+          var found = findHeadingSpecNodeById(entry.children, id);
+          if(found) return found;
+        }
+      }
+      return null;
+    }
+
+    function insertHeadingNode(node, parentId){
+      if(!node || !node.id) return false;
+      if(!parentId){
+        HEADING_SPEC.push(node);
+        return true;
+      }
+      var parentNode = findHeadingSpecNodeById(HEADING_SPEC, parentId);
+      if(!parentNode){
+        console.warn('找不到父節點，無法插入標題：', node.id, 'parent:', parentId);
+        return false;
+      }
+      if(!Array.isArray(parentNode.children)){
+        parentNode.children = [];
+      }
+      parentNode.children.push(node);
+      return true;
+    }
+
+    function resolveExpectedParentMap(){
+      var parentMap = {};
+      var lastH1 = null;
+      var lastH2 = null;
+      for(var i=0; i<EXPECTED_HEADINGS.length; i++){
+        var entry = EXPECTED_HEADINGS[i];
+        if(!entry || !entry.id) continue;
+        var tag = (entry.tag || '').toLowerCase();
+        if(tag === 'h1'){
+          parentMap[entry.id] = null;
+          lastH1 = entry.id;
+          lastH2 = null;
+        }else if(tag === 'h2'){
+          parentMap[entry.id] = lastH1;
+          lastH2 = entry.id;
+        }else if(tag === 'h3'){
+          parentMap[entry.id] = lastH2 || lastH1;
+        }else{
+          parentMap[entry.id] = lastH2 || lastH1;
+        }
+      }
+      return parentMap;
+    }
+
+    // === 將 EXPECTED_HEADINGS 與現有 HEADING_SPEC 比對後補齊（不破壞原排序）===
+    function mergeExpectedHeadingsIntoSpec(){
+      if(!Array.isArray(HEADING_SPEC)){
+        console.error('HEADING_SPEC 非陣列，請檢查初始化。');
+        return;
+      }
+      var existing = new Set();
+      collectExistingHeadingIds(HEADING_SPEC, existing);
+      var parentMap = resolveExpectedParentMap();
+      var additions = [];
+      for(var i=0; i<EXPECTED_HEADINGS.length; i++){
+        var entry = EXPECTED_HEADINGS[i];
+        if(!entry || !entry.id) continue;
+        if(existing.has(entry.id)) continue;
+        var node = {
+          id:entry.id,
+          tag:entry.tag,
+          label:entry.label
+        };
+        if(entry.tag && entry.tag.toLowerCase() !== 'h3'){
+          node.children = [];
+        }
+        var parentId = parentMap[entry.id] || null;
+        if(insertHeadingNode(node, parentId)){
+          additions.push(entry.id);
+          existing.add(entry.id);
+        }
+      }
+      if(additions.length === 0){
+        console.info('HEADING_SPEC 已包含所有預期 H1～H3。');
+        return;
+      }
+      rebuildHeadingIndex();
+      console.info('已補入缺漏標題：', additions);
+    }
+
+    // === 檢查 DOM 目標映射缺漏（只針對目前確定需新增的一筆）===
+    function ensureDomTargets(){
+      if(typeof HEADING_DOM_TARGETS !== 'object' || !HEADING_DOM_TARGETS){
+        console.error('HEADING_DOM_TARGETS 未初始化。');
+        return;
+      }
+      if(!HEADING_DOM_TARGETS['h3-goals-call-consult']){
+        HEADING_DOM_TARGETS['h3-goals-call-consult'] = {
+          selector:'#contactVisitGroup .contact-visit-card[data-card="call"] label.inline-checkbox',
+          mode:'labelHeading',
+          className:'h3'
+        };
+        console.info('已新增 DOM 對應：h3-goals-call-consult');
+      }
+    }
+
+    const HEADING_INDEX = {};
+    let HEADING_INDEX_ORDER = 0;
+
+    function assignHeadingEntries(entries, parent){
+      if(!Array.isArray(entries)) return;
+      entries.forEach(function(entry){
+        if(!entry || !entry.id) return;
+        const node = {
+          id:entry.id,
+          label:entry.label || '',
+          tag:entry.tag || (parent ? parent.tag : 'h1'),
+          level:entry.tag ? Number(entry.tag.replace(/[^0-9]/g,'')) || (parent ? parent.level + 1 : 1) : (parent ? parent.level + 1 : 1),
+          page:entry.page || (parent ? parent.page : ''),
+          parentId:parent ? parent.id : null,
+          order:HEADING_INDEX_ORDER++,
+          children:Array.isArray(entry.children) ? entry.children.map(function(child){ return child.id; }) : []
+        };
+        HEADING_INDEX[node.id] = node;
+        if(Array.isArray(entry.children) && entry.children.length){
+          assignHeadingEntries(entry.children, node);
+        }
+      });
+    }
+
+    function rebuildHeadingIndex(){
+      Object.keys(HEADING_INDEX).forEach(function(key){
+        delete HEADING_INDEX[key];
+      });
+      HEADING_INDEX_ORDER = 0;
+      assignHeadingEntries(HEADING_SPEC, null);
+      return HEADING_INDEX;
+    }
+
+    rebuildHeadingIndex();
 
     function getHeadingEntry(anchorId){
       return anchorId ? HEADING_INDEX[anchorId] || null : null;
@@ -17246,8 +17442,22 @@
       }
       prepareCaseProfileLayout();
       renderServicePlanEditor();
-      applyHeadingSpecToDom();
-      const headingSpecReport = logHeadingSpecReport();
+      let headingSpecReport = null;
+      if(typeof window !== 'undefined' && !window.__HEADING_SPEC_PATCHED__){
+        window.__HEADING_SPEC_PATCHED__ = true;
+        try{
+          mergeExpectedHeadingsIntoSpec();
+          ensureDomTargets();
+          applyHeadingSpecToDom();
+          headingSpecReport = logHeadingSpecReport();
+        }catch(err){
+          console.error('修補 H1～H3 及 DOM 對應時發生錯誤：', err);
+        }
+      }
+      if(!headingSpecReport){
+        applyHeadingSpecToDom();
+        headingSpecReport = logHeadingSpecReport();
+      }
       handleHeadingSpecValidation(headingSpecReport);
       initHeadingSpecToast();
       ensureAllGroupBodies(document);


### PR DESCRIPTION
## Summary
- add an authoritative EXPECTED_HEADINGS list plus utilities to merge missing entries into HEADING_SPEC and DOM targets
- rebuild the heading index so it can be refreshed after merging and add the new h3-goals-call-consult mapping
- adjust sidebar initialization to apply the patch once before heading validation runs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d440e13a34832b86ef961b98578afe