### PR TITLE
Refine AA01 sidebar design tokens

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -15,81 +15,57 @@
     /* ===== AA01 表單 — 放大字級、強對比、兩欄桌機、單欄手機、觸控友善 =====
        尺寸基準（依需求可再調）：
        - 根字級（html）：桌機 19→20px（視寬度），手機依檔位 clamp(20px~26px)
-       - 內文/標籤：≥16–18px（隨 font-scale 比例放大）
+       - 內文/標籤：≥16–18px（依字級檔位調整）
        - 控制元件字級：標準 18px；大字約 22px；特大約 24px（避免 iOS 聚焦放大）
        - 輸入框高度：標準 52px 起，依檔位漸增；主按鈕同步放大；核取方塊 26→34px（觸控）
     */
 
     :root{
-      /* 色彩（提高對比） */
       --bg:#ffffff;
       --card:#ffffff;
-      --card-alt:#f9fbff;            /* 淺藍區隔不同 group（交錯使用） */
-      --border:#dfe3ea;              /* 較實邊框 */
-      --border-strong:#c7cfdb;
       --text:#111111;
-      --label:#333333;               /* Label 由 #6a6a6a 提升為 #333 */
-      --placeholder:#555555;         /* Placeholder 加深，避免與 disabled 混淆 */
-      --title:#0B57D0;               /* 區塊標題與主色（可改為 #222 深灰） */
-      --accent:#0B57D0;              /* 主要行為色（按鈕/Focus） */
-      --accent-weak:rgba(11,87,208,.12); /* Focus ring */
-      --status-complete-bg:rgba(34,197,94,.14);
-      --status-complete-border:rgba(22,163,74,.45);
-      --status-complete-text:#065f46;
-      --status-complete-strong:#047857;
-      --status-partial-bg:rgba(253,224,71,.18);
-      --status-partial-border:rgba(217,119,6,.45);
-      --status-partial-text:#92400e;
-      --status-partial-strong:#b45309;
-      --status-pending-bg:rgba(226,232,240,.7);
-      --status-pending-border:rgba(148,163,184,.6);
-      --status-pending-text:#1f2937;
-      --status-pending-strong:#1f2937;
-      --status-optional-bg:rgba(226,232,240,.3);
-      --status-optional-border:rgba(203,213,225,.6);
-      --status-optional-text:#475569;
-      --status-optional-strong:#475569;
-      --side-nav-bg:#f8fafc;
-      --side-nav-border:rgba(148,163,184,.45);
-      --side-nav-text:#0f172a;
-      --side-nav-muted:#475569;
+      --border:#dfe3ea;
 
-      /* 尺寸系統 */
-      --space-unit:4px;
-      --space-xxs:calc(var(--space-unit) * 1);   /* 4px */
-      --space-xs:calc(var(--space-unit) * 2);    /* 8px */
-      --space-sm:calc(var(--space-unit) * 3);    /* 12px */
-      --space-md:calc(var(--space-unit) * 4);    /* 16px */
-      --space-lg:calc(var(--space-unit) * 6);    /* 24px */
-      --gap-base:var(--space-xs);
-      --gap:var(--gap-base);
-      --group-padding-base:var(--space-sm);
-      --group-padding:var(--group-padding-base);
-      --group-spacing-base:var(--space-sm);
-      --group-spacing:var(--group-spacing-base);
+      --accent:#0B57D0;
+      --accent-weak:rgba(11,87,208,.12);
+
+      --status-complete:4 120 87;
+      --status-partial:180 83 9;
+      --status-pending:31 41 55;
+      --status-optional:71 85 105;
+
+      --space-xxs:4px;
+      --space-xs:8px;
+      --space-sm:12px;
+      --space-md:16px;
+      --space-lg:24px;
+
+      --fs-base:1rem;
+      --fs-title:clamp(1.25rem, 1.1rem + .35vw, 1.5rem);
+      --fs-ctrl:18px;
+
       --radius:10px;
       --shadow:0 10px 30px rgba(15,23,42,.08);
-
-      --fs-base:1rem;                               /* 由 html 根字級決定（19–22px） */
-      --font-scale:1;
-      --line-height:1.65;
-      --fs-title-base:clamp(1.25rem, 1.1rem + .35vw, 1.5rem);
-      --fs-title:calc(var(--fs-title-base) * var(--font-scale));
-      --fs-ctrl:18px;                               /* input/select/textarea 固定 18px */
-      --fs-label-base:calc(var(--fs-ctrl) - 3px);    /* label 比輸入框小 3px */
-      --fs-label:calc(var(--fs-label-base) * var(--font-scale));
-      --fs-button:calc(var(--fs-ctrl) - 1px);
-      --ctrl-padding-block:8px;                     /* 垂直 padding 控制高度 */
-      --ctrl-padding-inline:12px;
-      --button-padding-inline:16px;
-      --button-small-padding-inline:12px;
+      --ctrl-padding-block:var(--space-xs);
+      --ctrl-padding-inline:var(--space-sm);
+      --button-padding-inline:var(--space-md);
+      --button-small-padding-inline:var(--space-sm);
       --button-padding-block:calc(var(--ctrl-padding-block) - 1px);
       --button-padding-block-sm:calc(var(--ctrl-padding-block) - 3px);
       --h-input:calc(var(--fs-ctrl) + 2 * var(--ctrl-padding-block));
-      --h-button:calc(var(--fs-button) + 2 * var(--button-padding-block));
-      --h-button-sm:calc(var(--fs-button) + 2 * var(--button-padding-block-sm));
-      --checkbox:26px;                              /* 核取方塊 */
-      /* 讓主容器寬度能更彈性，優先 90vw，其次 layout-max（預設 1440，可改） */
+      --h-button:calc(var(--fs-ctrl) + 2 * var(--button-padding-block));
+      --h-button-sm:calc(var(--fs-ctrl) + 2 * var(--button-padding-block-sm));
+      --checkbox:calc(var(--space-lg) + var(--space-xxs));
+      --fab-h:0px;
+      --fab-gap:calc(max(20px, env(safe-area-inset-bottom) + 20px));
+      --app-top-offset:0px;
+      --side-nav-w:280px;
+      --sticky-padding-block:var(--space-xs);
+      --sticky-padding-inline:clamp(10px, 3.2vw, 18px);
+      --wizard-index-size:34px;
+      --wizard-index-font:0.95rem;
+      --group-header-spacing:var(--space-xs);
+      --bottom-bar-min-height:48px;
       --layout-max:1440px;
       --section-col-min:340px;
       --section-col-max:560px;
@@ -98,39 +74,15 @@
       --grid-col-min-3:180px;
       --checkcol-min:190px;
       --textarea-min:110px;
-      --mobile-font-min:18px;
-      --mobile-font-fluid:4.8vw;
-      --mobile-font-max:20px;
-      --fab-h:0px;
-      --fab-gap:calc(max(20px, env(safe-area-inset-bottom) + 20px));
-      --app-top-offset:0px;
-      --side-nav-w:280px; /* 右側側欄寬度（可依需求調整） */
-      --sticky-padding-block:var(--space-xs);
-      --sticky-padding-inline:clamp(10px, 3.2vw, 18px);
-      --wizard-index-size:34px;
-      --wizard-index-font:0.95rem;
-      --wizard-gap:var(--space-xs);
-      --group-header-spacing:var(--space-xs);
-      --bottom-bar-min-height:48px;
-      /* 標題層級間距（Token） */
-      --space-h1-top:40px; --space-h1-bottom:24px;
-      --space-h2-top:32px; --space-h2-bottom:16px;
-      --space-h3-top:24px; --space-h3-bottom:12px;
-      --space-h4-top:16px; --space-h4-bottom:8px;
-      --brand-blue:#2563EB;
-      --h1-color:#0B1220; /* 最深黑藍 */
-      --h2-color:#111827; /* 深黑 */
-      --h3-color:#1F2937; /* 中深灰 */
-      --h4-color:#374151; /* 中灰 */
-      /* 三卡片（基本資訊/電聯家訪/偕同訪視者）內欄位一致寬度 */
       --intro-colw:clamp(260px, 28vw, 360px);
     }
 
     @media (max-width:1279px){
       :root{
         --intro-colw:clamp(220px, 60vw, 300px);
+        --checkcol-min:160px;
       }
-      html{ font-size:clamp(var(--mobile-font-min), var(--mobile-font-fluid), var(--mobile-font-max)); } 
+      html{ font-size:clamp(18px, 4.8vw, 20px); }
       .app-container{ padding-right:0; }
       .app-body-controls{ justify-content:center; }
     
@@ -259,20 +211,14 @@
         bottom:calc(var(--fab-h, 0px) + var(--space-lg));
       }
     
-      body{
-        margin:var(--space-sm);
-        --gap-base:var(--space-xs);
-        --group-padding-base:var(--space-xs);
-        --group-spacing-base:var(--space-xs);
-        --checkcol-min:160px;
-      }
-      .row, .autogrid{ gap:var(--gap); }
+      body{ margin:var(--space-sm); }
+      .row, .autogrid{ gap:var(--space-sm); }
       .datebox input[type="date"]{ font-size:var(--fs-ctrl); }
       .titlebar{ margin-bottom:var(--space-xs); }
-      .group, .section-card{ padding:var(--group-padding); }
+      .group, .section-card{ padding:var(--space-xs); }
       #contactVisitGroup .contact-visit-card{ padding:var(--space-xs); gap:var(--space-xxs); }
       #contactVisitGroup .contact-visit-card-body{ gap:var(--space-xs); }
-      .preview{ font-size:calc(var(--fs-base) * var(--font-scale) * 0.95); }
+      .preview{ font-size:calc(var(--fs-base) * 0.95); }
     
       .section-card-grid{ grid-template-columns:1fr; }
     
@@ -280,7 +226,7 @@
       .span-3{ grid-column:auto; }
     
 
-      body[data-fontscale="sm"]{ --checkbox:32px; }
+      body[data-fontscale="sm"]{ --checkbox:calc(var(--space-lg) + var(--space-xs)); }
     
       select{ min-height:64px; padding-top:14px; padding-bottom:14px; }
     
@@ -300,10 +246,19 @@
         grid-template-columns:minmax(0, 1fr) minmax(280px, 360px);
         align-items:stretch;
       }
+      .page-section[data-columns="2"][data-active="1"]{
+        display:grid;
+        grid-template-columns:repeat(2, minmax(var(--section-col-min), 1fr));
+        gap:var(--space-md);
+      }
+      .page-section[data-columns="2"][data-active="1"] > .group[data-span="full"],
+      .page-section[data-columns="2"][data-active="1"] > .section-intro-grid{
+        grid-column:1 / -1;
+      }
       #basicInfoGroup .basic-info-fields{
         display:grid;
         grid-template-columns:repeat(2, minmax(var(--intro-colw), 1fr));
-        column-gap:var(--gap);
+        column-gap:var(--space-sm);
         row-gap:var(--space-sm);
         justify-content:flex-start;
       }
@@ -332,7 +287,7 @@
       #careGoals_block{
         display:grid;
         grid-template-columns:minmax(0, 1fr) clamp(320px, 38%, 420px);
-        gap:var(--group-spacing);
+        gap:var(--space-md);
         align-items:flex-start;
       }
       #careGoals_block .section-group[data-group-id="4"]{
@@ -387,8 +342,8 @@
     html, body{ background:var(--bg); color:var(--text); }
     body{
       font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans TC", Arial, sans-serif;
-      font-size:calc(var(--fs-base) * var(--font-scale));
-      line-height:var(--line-height);
+      font-size:var(--fs-base);
+      line-height:1.65;
       letter-spacing:.2px;
       margin:clamp(var(--space-xs), 4vw, var(--space-md));
       -webkit-tap-highlight-color:transparent;
@@ -407,42 +362,31 @@
       border:0;
     }
     body[data-fontscale="sm"]{
-      --font-scale:1;
       --fs-ctrl:20px;
-      --ctrl-padding-block:9px;
-      --ctrl-padding-inline:14px;
-      --button-padding-inline:17px;
-      --button-small-padding-inline:15px;
-      --checkbox:28px;
-      --line-height:1.7;
-      --mobile-font-min:20px;
-      --mobile-font-fluid:5.2vw;
-      --mobile-font-max:23px;
+      --checkbox:calc(var(--space-lg) + var(--space-xxs));
+      line-height:1.7;
     }
     body[data-fontscale="xl"]{
-      --font-scale:1.2;
+      font-size:calc(var(--fs-base) * 1.15);
       --fs-ctrl:24px;
-      --ctrl-padding-block:11px;
-      --ctrl-padding-inline:16px;
-      --button-padding-inline:19px;
-      --button-small-padding-inline:17px;
-      --checkbox:34px;
-      --line-height:1.78;
-      --mobile-font-min:22px;
-      --mobile-font-fluid:5.8vw;
-      --mobile-font-max:25px;
+      --ctrl-padding-block:var(--space-sm);
+      --ctrl-padding-inline:var(--space-md);
+      --button-padding-inline:var(--space-lg);
+      --button-small-padding-inline:var(--space-md);
+      --checkbox:calc(var(--space-lg) + var(--space-sm));
+      line-height:1.78;
     }
-    body[data-uimode="comfort"]{
-      --gap:calc(var(--gap-base) * 0.9);
-      --group-padding:calc(var(--group-padding-base) * 0.9);
-      --group-spacing:calc(var(--group-spacing-base) * 0.9);
-    }
+    body[data-uimode="comfort"] .group,
+    body[data-uimode="comfort"] .section-card{ padding:var(--space-md); }
+    body[data-uimode="comfort"] .app-main,
+    body[data-uimode="comfort"] .page-section[data-active="1"]{ gap:var(--space-lg); }
     body[data-vertical-density="compact"]{
-      --gap:calc(var(--gap-base) * 0.9);
-      --group-padding:calc(var(--group-padding-base) * 0.9);
-      --group-spacing:calc(var(--group-spacing-base) * 0.9);
-      line-height:calc(var(--line-height) * 0.95);
+      line-height:1.55;
     }
+    body[data-vertical-density="compact"] .group,
+    body[data-vertical-density="compact"] .section-card{ padding:var(--space-xs); }
+    body[data-vertical-density="compact"] .app-main,
+    body[data-vertical-density="compact"] .page-section[data-active="1"]{ gap:var(--space-sm); }
     .app-container{
       width:100%;
       margin:0 auto;
@@ -482,7 +426,7 @@
     .app-main{
       display:flex;
       flex-direction:column;
-      gap:var(--group-spacing);
+      gap:var(--space-md);
       padding-inline:clamp(12px, 4vw, 24px);
       box-sizing:border-box;
     }
@@ -495,7 +439,7 @@
       background:var(--card);
       border:1px solid var(--border);
       border-radius:var(--radius);
-      padding:var(--group-padding);
+      padding:var(--space-sm);
       box-shadow:var(--shadow);
       width:100%;
       box-sizing:border-box;
@@ -542,7 +486,7 @@
     .group[data-collapsed="1"] .group-collapse-icon{ transform:rotate(-90deg); }
     body[data-uimode="review"] .group{ border-radius:8px; }
     /* 交錯輕底以分區（依 page-section 容器交錯） */
-    .page-section[data-active="1"] > .group:nth-of-type(odd){ background:var(--card-alt); }
+    .page-section[data-active="1"] > .group:nth-of-type(odd){ background:rgb(11 87 208 / 0.04); }
 
     /* 標題列與標題字（以 H 系列為主） */
     .titlebar{
@@ -562,46 +506,46 @@
     /* ===== Headings System (H1–H6) ===== */
     .h1{
       display:block;
-      font-weight:800; /* Extra Bold */
-      color:var(--h1-color);
+      font-weight:800;
+      color:rgb(17 17 17 / 0.95);
       font-size:clamp(26px, 2.5vw, 34px);
-      margin-top:var(--space-h1-top);
-      margin-bottom:var(--space-h1-bottom);
+      margin-top:calc(var(--space-lg) + var(--space-md));
+      margin-bottom:var(--space-lg);
       padding-bottom:6px;
-      border-bottom:2px solid var(--brand-blue);
+      border-bottom:2px solid var(--accent);
     }
     .h2{
       display:block;
-      font-weight:800; /* Extra Bold */
-      color:var(--h1-color);
+      font-weight:800;
+      color:rgb(17 17 17 / 0.9);
       font-size:clamp(21px, 2.2vw, 28px);
-      margin-top:var(--space-h2-top);
-      margin-bottom:var(--space-h2-bottom);
+      margin-top:calc(var(--space-lg) + var(--space-xs));
+      margin-bottom:var(--space-md);
       padding-left:14px;
-      border-left:5px solid var(--brand-blue);
+      border-left:5px solid var(--accent);
       border-bottom:none !important;
       letter-spacing:.01em;
     }
     .h3{
       display:block;
-      font-weight:600; /* Semi Bold */
-      color:#1f2a44;
+      font-weight:600;
+      color:rgb(17 17 17 / 0.85);
       font-size:clamp(19px, 1.75vw, 23px);
-      margin-top:var(--space-h3-top);
-      margin-bottom:var(--space-h3-bottom);
+      margin-top:var(--space-lg);
+      margin-bottom:var(--space-sm);
       padding-bottom:6px;
-      border-bottom:1px solid #d4d8e3; /* 極淺灰 */
+      border-bottom:1px solid rgb(17 17 17 / 0.12);
       letter-spacing:.005em;
     }
     .h4{
       display:block;
-      font-weight:500; /* Medium */
-      color:var(--h4-color);
+      font-weight:500;
+      color:rgb(17 17 17 / 0.75);
       font-size:16px;
-      margin-top:var(--space-h4-top);
-      margin-bottom:var(--space-h4-bottom);
+      margin-top:var(--space-md);
+      margin-bottom:var(--space-xs);
       padding:var(--space-xxs) var(--space-xs);
-      background:#F9FAFB; /* 淺灰底 */
+      background:#F9FAFB;
       border-radius:8px;
     }
     /* 段落（H5對應） */
@@ -614,27 +558,27 @@
     .h4.heading-tier,
     .h5.heading-tier{ border-left:none; border-bottom:none; padding-left:0; background:none; }
     .heading-tier--primary{
-      color:var(--h1-color);
+      color:rgb(17 17 17 / 0.9);
       font-size:clamp(22px, 1.9vw, 28px);
-      margin-top:var(--space-h2-top);
-      margin-bottom:var(--space-h2-bottom);
+      margin-top:calc(var(--space-lg) + var(--space-xs));
+      margin-bottom:var(--space-md);
       padding-bottom:6px;
-      border-bottom:1px solid var(--border-strong);
+      border-bottom:1px solid var(--border);
     }
     .heading-tier--section{
-      color:var(--h2-color);
+      color:rgb(17 17 17 / 0.85);
       font-size:clamp(19px, 1.6vw, 23px);
-      margin-top:var(--space-h3-top);
-      margin-bottom:var(--space-h3-bottom);
-      border-left:4px solid var(--brand-blue);
+      margin-top:var(--space-lg);
+      margin-bottom:var(--space-sm);
+      border-left:4px solid var(--accent);
       padding-left:12px;
       border-radius:4px;
     }
     .heading-tier--subsection{
-      color:var(--h3-color);
+      color:rgb(17 17 17 / 0.7);
       font-size:18px;
-      margin-top:var(--space-h4-top);
-      margin-bottom:var(--space-h4-bottom);
+      margin-top:var(--space-md);
+      margin-bottom:var(--space-xs);
     }
     /* 佈局：桌機固定兩欄、行動單欄（避免三欄造成橫向拉長） */
     [data-section],
@@ -642,16 +586,16 @@
     .group{
       scroll-margin-top:var(--app-top-offset);
     }
-    .row{ display:flex; gap:var(--gap); flex-wrap:wrap; align-items:flex-start; margin-bottom:var(--space-xs); }
+    .row{ display:flex; gap:var(--space-sm); flex-wrap:wrap; align-items:flex-start; margin-bottom:var(--space-xs); }
     .row > div{ flex:1 1 min(100%, 360px); min-width:min(100%, 240px); max-width:720px; }
     .row > [data-field-size="short"],
     .section-group-body > [data-field-size="short"]{
-      flex:1 1 calc(33.333% - var(--gap));
+      flex:1 1 calc(33.333% - var(--space-sm));
       min-width:180px;
     }
     .row > [data-field-size="medium"],
     .section-group-body > [data-field-size="medium"]{
-      flex:1 1 calc(50% - var(--gap));
+      flex:1 1 calc(50% - var(--space-sm));
       min-width:260px;
     }
     .row > [data-field-size="long"],
@@ -662,8 +606,8 @@
     
 
     /* 標籤與 Placeholder（加大字、提升對比） */
-    label{ display:block; font-size:var(--fs-label); margin-bottom:var(--space-xxs); color:var(--label); }
-    :where(input,select,textarea)::placeholder{ color:var(--placeholder); opacity:1; font-size:calc(var(--fs-ctrl) - 2px); }
+    label{ display:block; font-size:calc(var(--fs-ctrl) - 2px); margin-bottom:var(--space-xxs); color:rgb(17 17 17 / 0.75); }
+    :where(input,select,textarea)::placeholder{ color:rgb(17 17 17 / 0.55); opacity:1; font-size:calc(var(--fs-ctrl) - 2px); }
     :where(input,select,textarea,button,.datebox){ scroll-margin-top:calc(var(--app-top-offset) + var(--space-md)); }
 
     /* 表單元件：20px 字級，56px 高度（iOS 聚焦不縮放） */
@@ -686,7 +630,7 @@
     /* Focus 樣式：清楚但不刺眼 */
     input:focus, select:focus, textarea:focus{
       outline:none;
-      border-color:var(--title);
+      border-color:var(--accent);
       box-shadow:0 0 0 3px var(--accent-weak);
     }
 
@@ -714,7 +658,7 @@
       border-radius:10px;
       border:1px solid var(--border);
       background:#fff; color:#111; font-weight:700; cursor:pointer;
-      line-height:1.1; touch-action:manipulation; font-size:var(--fs-button);
+      line-height:1.1; touch-action:manipulation; font-size:var(--fs-ctrl);
     }
     button:hover{ background:#f7f7f7; }
     button.primary{ background:var(--accent); color:#fff; border-color:var(--accent); }
@@ -734,7 +678,7 @@
       min-height:max(var(--h-button-sm), 44px);
       min-width:56px;
       padding:calc(var(--button-padding-block-sm) + 2px) var(--button-small-padding-inline);
-      font-size:var(--fs-button);
+      font-size:var(--fs-ctrl);
     }
     /* 可選：若於按鈕加入 data-ic="plus"/"minus"，會自動加上 + / - 圖示 */
     button[data-ic="plus"]::before{ content:"+"; margin-right:.25em; font-weight:900; }
@@ -745,7 +689,7 @@
       top:0;
       z-index:1000;
       padding:var(--sticky-padding-block) var(--sticky-padding-inline);
-      margin-bottom:var(--group-spacing);
+      margin-bottom:var(--space-md);
     }
     .app-sticky-inner{
       width:min(1360px, 100%);
@@ -787,7 +731,7 @@
     }
     .wizard-quickjump label{
       font-weight:600;
-      color:var(--label);
+      color:rgb(17 17 17 / 0.75);
       font-size:0.95rem;
     }
     .sticky-summary{
@@ -804,7 +748,7 @@
     }
     .summary-item.summary-progress{ flex-wrap:wrap; }
     .summary-label{ font-size:0.85rem; color:#475569; font-weight:600; }
-    .summary-value{ font-size:1.05rem; font-weight:700; color:var(--title); word-break:break-word; }
+    .summary-value{ font-size:1.05rem; font-weight:700; color:rgb(17 17 17 / 0.9); word-break:break-word; }
     .summary-progress-bar{ position:relative; height:10px; border-radius:999px; background:#e2e8f0; overflow:hidden; min-width:120px; }
     .summary-progress-fill{ position:absolute; inset:0; width:0%; border-radius:999px; background:var(--accent); transition:width .3s ease; }
     .summary-progress-text,
@@ -828,7 +772,7 @@
       background:transparent;
       font-weight:600;
       font-size:0.95rem;
-      color:var(--title);
+      color:var(--accent);
       cursor:pointer;
       transition:background .2s ease, color .2s ease;
     }
@@ -851,12 +795,12 @@
       border-radius:10px;
       border:1px solid var(--border);
       background:#fff;
-      color:var(--label);
-      font-size:var(--fs-button);
+      color:rgb(17 17 17 / 0.75);
+      font-size:var(--fs-ctrl);
     }
     .wizard-quickjump select:focus{
       outline:none;
-      border-color:var(--title);
+      border-color:var(--accent);
       box-shadow:0 0 0 3px var(--accent-weak);
     }
     
@@ -867,7 +811,7 @@
       border-radius:999px;
       border:1px solid var(--border);
       background:#fff;
-      color:var(--label);
+      color:rgb(17 17 17 / 0.75);
       font-weight:600;
       cursor:pointer;
       transition:background .15s ease, color .15s ease, border-color .15s ease;
@@ -882,7 +826,7 @@
       display:flex;
       justify-content:flex-start;
       align-items:center;
-      gap:var(--wizard-gap);
+      gap:var(--space-sm);
       flex-wrap:wrap;
     }
     .wizard-step{
@@ -895,7 +839,7 @@
       border:none;
       background:none;
       cursor:pointer;
-      color:var(--label);
+      color:rgb(17 17 17 / 0.75);
       font-weight:600;
       padding:var(--space-xxs) var(--space-xs);
       border-radius:12px;
@@ -907,7 +851,7 @@
     }
     .wizard-step[data-locked="1"]:hover{
       background:none;
-      color:var(--label);
+      color:rgb(17 17 17 / 0.75);
     }
     .wizard-step::before{
       content:'';
@@ -949,7 +893,7 @@
     }
     .wizard-step:hover{
       background:rgba(11,87,208,.06);
-      color:var(--title);
+      color:var(--accent);
     }
     .wizard-step[data-status="active"] .wizard-index,
     .wizard-step[data-status="done"] .wizard-index{
@@ -963,8 +907,8 @@
     .wizard-step[data-status="active"] .wizard-index{
       transform:scale(1.05);
     }
-    .wizard-step[data-status="active"] .wizard-label{ color:var(--title); }
-    .wizard-step[data-status="done"] .wizard-label{ color:#0b1d4d; }
+    .wizard-step[data-status="active"] .wizard-label{ color:var(--accent); }
+    .wizard-step[data-status="done"] .wizard-label{ color:rgb(var(--status-complete) / 1); }
     
     .page-section{
       display:none;
@@ -977,18 +921,13 @@
       --section-col-max:100%;
       --section-col-preferred:100%;
     }
-    .page-section[data-columns="3"]{
-      --section-col-min:300px;
-      --section-col-max:420px;
-      --section-col-preferred:33.333%;
-    }
     .page-section[data-active="1"]{
       display:flex;
       flex-wrap:wrap;
-      gap:var(--group-spacing);
+      gap:var(--space-md);
       align-items:stretch;
       justify-content:flex-start;
-      margin-bottom:var(--group-spacing);
+      margin-bottom:var(--space-lg);
     }
     .page-section[data-columns="1"][data-active="1"]{
       flex-direction:column;
@@ -1007,7 +946,7 @@
         display:grid;
         grid-template-columns:minmax(var(--section-col-min), .4fr) minmax(var(--section-col-min), .6fr);
         align-items:start;
-        gap:var(--group-spacing);
+        gap:var(--space-md);
       }
       .page-section[data-columns="2"][data-active="1"] > .group{
         min-width:0;
@@ -1019,7 +958,7 @@
       }
     }
 
-    .summary-title{ font-weight:700; color:var(--title); margin-bottom:8px; }
+    .summary-title{ font-weight:700; color:rgb(17 17 17 / 0.9); margin-bottom:8px; }
     .summary-actions{
       display:flex;
       justify-content:flex-end;
@@ -1081,7 +1020,7 @@
     #basicInfoGroup .basic-info-row{
       display:flex;
       flex-wrap:wrap;
-      gap:var(--gap);
+      gap:var(--space-sm);
       align-items:flex-start;
     }
     #basicInfoGroup .basic-info-field{
@@ -1173,7 +1112,7 @@
     #visitPartnersCard .extra-row{
       display:flex;
       flex-wrap:wrap;
-      gap:var(--gap);
+      gap:var(--space-sm);
       align-items:flex-start;
       margin-top:var(--space-xs);
     }
@@ -1213,9 +1152,9 @@
     #visitPartnersCard .extra-remove span{ pointer-events:none; }
     #extras_conflict{
       position:absolute;
-      top:var(--group-padding);
-      right:var(--group-padding);
-      max-width:calc(100% - 2 * var(--group-padding));
+      top:var(--space-sm);
+      right:var(--space-sm);
+      max-width:calc(100% - 2 * var(--space-sm));
       padding:10px 12px;
       border-radius:10px;
       border:1px solid #facc15;
@@ -1258,7 +1197,7 @@
       gap:var(--space-sm);
       flex-wrap:wrap;
     }
-    .location-toolbar .location-current{ font-weight:600; color:var(--label); }
+    .location-toolbar .location-current{ font-weight:600; color:rgb(17 17 17 / 0.75); }
     .location-toolbar .location-actions{ display:flex; gap:8px; flex-wrap:wrap; }
     .location-switch button[data-active="1"],
     .location-actions button[data-active="1"]{
@@ -1279,9 +1218,9 @@
       border-radius:999px;
       border:1px solid var(--border);
       background:#fff;
-      color:var(--label);
+      color:rgb(17 17 17 / 0.75);
       font-weight:600;
-      font-size:calc(var(--fs-button) - 1px);
+      font-size:calc(var(--fs-ctrl) - 2px);
       cursor:pointer;
       transition:background .15s ease, color .15s ease, border-color .15s ease;
     }
@@ -1309,7 +1248,7 @@
     }
     .section-progress-text{
       font-weight:600;
-      color:var(--label);
+      color:rgb(17 17 17 / 0.75);
       margin-bottom:6px;
     }
     .section-progress-bar{
@@ -1351,7 +1290,7 @@
       padding:0;
       font-size:1.05rem;
       font-weight:700;
-      color:var(--title);
+      color:var(--accent);
       cursor:pointer;
       display:flex;
       align-items:center;
@@ -1362,7 +1301,7 @@
     .section-group-toggle::before{
       content:'▾';
       font-size:.9rem;
-      color:var(--title);
+      color:var(--accent);
       transition:transform .2s ease;
     }
     .section-group[data-collapsed="1"] .section-group-toggle::before{
@@ -1426,7 +1365,7 @@
     }
     .checkcol label::before{ content:''; display:none; }
     .inline-checkbox{
-      display:inline-flex; align-items:center; gap:var(--space-xxs); font-size:var(--fs-label); color:var(--label); flex-wrap:wrap;
+      display:inline-flex; align-items:center; gap:var(--space-xxs); font-size:calc(var(--fs-ctrl) - 2px); color:rgb(17 17 17 / 0.75); flex-wrap:wrap;
     }
     .inline-checkbox input[type="checkbox"]{ width:calc(var(--checkbox) - 4px); height:calc(var(--checkbox) - 4px); }
     .checkcol input[type=checkbox]{ width:var(--checkbox); height:var(--checkbox); }
@@ -1507,7 +1446,7 @@
     #careGoals_block{
       display:flex;
       flex-direction:column;
-      gap:var(--group-spacing);
+      gap:var(--space-md);
     }
     #careGoals_block .section-group{
       margin:0;
@@ -1570,8 +1509,8 @@
     .lesion-size-grid{ display:flex; gap:var(--space-sm); flex-wrap:wrap; }
     .lesion-size-field{ flex:1 1 140px; position:relative; }
     .lesion-size-field input{ padding-right:42px; }
-    .lesion-size-field .unit{ position:absolute; right:14px; top:50%; transform:translateY(-50%); color:var(--label); font-weight:600; pointer-events:none; }
-    .lesion-area{ margin-top:var(--space-xs); font-weight:600; color:var(--label); }
+    .lesion-size-field .unit{ position:absolute; right:14px; top:50%; transform:translateY(-50%); color:rgb(17 17 17 / 0.75); font-weight:600; pointer-events:none; }
+    .lesion-area{ margin-top:var(--space-xs); font-weight:600; color:rgb(17 17 17 / 0.75); }
     .action-list{ display:flex; flex-direction:column; gap:var(--space-sm); }
     .action-item{ border:1px dashed var(--border); border-radius:var(--radius); padding:var(--space-sm); background:#fff; display:flex; flex-direction:column; gap:var(--space-xs); }
     .action-item-fields{ display:flex; flex-direction:column; gap:var(--space-xs); }
@@ -1611,14 +1550,14 @@
     .plan-workspace{
       display:flex;
       flex-direction:column;
-      gap:var(--group-spacing);
+      gap:var(--space-md);
       width:100%;
     }
     .plan-workspace-main,
     .plan-workspace-side{
       display:flex;
       flex-direction:column;
-      gap:var(--group-spacing);
+      gap:var(--space-md);
     }
     .plan-workspace-main > .group,
     .plan-workspace-side > .group{
@@ -1650,7 +1589,7 @@
     }
     .plan-category-heading .h3{
       font-weight:700;
-      color:var(--title);
+      color:var(--accent);
       margin:0;
     }
     .plan-category-body{
@@ -1660,11 +1599,11 @@
     }
     .plan-category-meta{
       border-style:dashed;
-      background:var(--card-alt);
+      background:rgb(11 87 208 / 0.05);
     }
     .plan-empty-hint{
       font-size:0.95rem;
-      color:var(--label);
+      color:rgb(17 17 17 / 0.75);
       padding:var(--space-sm);
       border:1px dashed var(--border);
       border-radius:var(--radius);
@@ -1674,7 +1613,7 @@
       border:1px dashed var(--border);
       border-radius:var(--radius);
       padding:var(--space-sm);
-      background:var(--card-alt);
+      background:rgb(11 87 208 / 0.05);
     }
     .plan-entry + .plan-entry{ margin-top:var(--space-sm); }
     .plan-entry-header{
@@ -1691,13 +1630,13 @@
     .plan-entry-grid .full{ grid-column:1/-1; }
     .plan-hint{
       font-size:0.9rem;
-      color:var(--label);
+      color:rgb(17 17 17 / 0.75);
       opacity:0.85;
       margin-top:var(--space-xs);
     }
     .plan-field.auto-summary .auto-summary-box{
       padding:12px 16px;
-      border:1px solid var(--border-strong);
+      border:1px solid var(--border);
       border-radius:10px;
       background:#f0f4ff;
       color:#0b1d4d;
@@ -1727,7 +1666,7 @@
     }
     .plan-qty-hint{
       font-weight:600;
-      color:var(--label);
+      color:rgb(17 17 17 / 0.75);
       font-size:0.95rem;
       margin-right:4px;
     }
@@ -1949,7 +1888,7 @@
       background:#eef4ff;
       border:1px solid #cdd9ff; border-radius:12px;
       white-space:pre-wrap; font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-      color:#0f172a; max-height:55vh; overflow:auto; font-size:calc(var(--fs-base) * var(--font-scale) * 0.95);
+      color:#0f172a; max-height:55vh; overflow:auto; font-size:calc(var(--fs-base) * 0.95);
     }
     #goalPreview.goal-preview-empty{ color:#6b7280; }
     .preview-toolbar{
@@ -1995,7 +1934,7 @@
     }
     .preview-card-title{
       font-weight:700;
-      color:var(--title);
+      color:var(--accent);
       font-size:1.05rem;
     }
     .preview-card-actions{
@@ -2088,8 +2027,8 @@
       right:max(var(--space-md), env(safe-area-inset-right) + var(--space-md));
       top:calc(var(--app-top-offset) + var(--space-md));
       width:var(--side-nav-w);
-      background:var(--side-nav-bg);
-      border:1px solid var(--side-nav-border);
+      background:var(--card);
+      border:1px solid var(--border);
       border-radius:14px;
       box-shadow:var(--shadow);
       padding:var(--space-sm);
@@ -2097,13 +2036,13 @@
       flex-direction:column;
       gap:var(--space-xs);
       z-index:38;
-      color:var(--side-nav-text);
+      color:rgb(17 17 17 / 0.9);
       max-height:calc(100vh - var(--app-top-offset) - 2 * var(--space-md));
       overflow:auto;
       overscroll-behavior:contain;
     }
     .side-nav[data-empty="1"]{ display:none; }
-    .side-nav-title{ font-weight:700; color:var(--title); font-size:1rem; }
+    .side-nav-title{ font-weight:700; color:rgb(17 17 17 / 0.9); font-size:1rem; }
     .side-nav-list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:var(--space-xs); }
     .side-nav-item{
       display:flex;
@@ -2127,7 +2066,7 @@
       background:none;
       border:none;
       padding:0;
-      color:var(--side-nav-muted);
+      color:rgb(17 17 17 / 0.65);
       font-size:0.95rem;
       cursor:pointer;
       transition:color .2s ease;
@@ -2136,39 +2075,39 @@
       text-overflow:ellipsis;
     }
     .side-nav-link:hover,
-    .side-nav-link:focus{ color:var(--title); outline:none; }
+    .side-nav-link:focus{ color:var(--accent); outline:none; }
     .side-nav-count{
       margin-left:auto;
       font-size:0.85rem;
       font-weight:600;
-      color:var(--side-nav-text);
+      color:rgb(17 17 17 / 0.75);
       font-variant-numeric:tabular-nums;
       text-align:right;
     }
     .side-nav-item[data-status="complete"]{
-      background:var(--status-complete-bg);
-      border-color:var(--status-complete-border);
+      background:rgb(var(--status-complete) / 0.14);
+      border-color:rgb(var(--status-complete) / 0.45);
     }
-    .side-nav-item[data-status="complete"] .side-nav-link{ color:var(--status-complete-text); }
-    .side-nav-item[data-status="complete"] .side-nav-count{ color:var(--status-complete-strong); }
+    .side-nav-item[data-status="complete"] .side-nav-link,
+    .side-nav-item[data-status="complete"] .side-nav-count{ color:rgb(var(--status-complete) / 1); }
     .side-nav-item[data-status="partial"]{
-      background:var(--status-partial-bg);
-      border-color:var(--status-partial-border);
+      background:rgb(var(--status-partial) / 0.18);
+      border-color:rgb(var(--status-partial) / 0.45);
     }
-    .side-nav-item[data-status="partial"] .side-nav-link{ color:var(--status-partial-text); }
-    .side-nav-item[data-status="partial"] .side-nav-count{ color:var(--status-partial-strong); }
+    .side-nav-item[data-status="partial"] .side-nav-link,
+    .side-nav-item[data-status="partial"] .side-nav-count{ color:rgb(var(--status-partial) / 1); }
     .side-nav-item[data-status="pending"]{
-      background:var(--status-pending-bg);
-      border-color:var(--status-pending-border);
+      background:rgb(var(--status-pending) / 0.18);
+      border-color:rgb(var(--status-pending) / 0.45);
     }
-    .side-nav-item[data-status="pending"] .side-nav-link{ color:var(--status-pending-text); }
-    .side-nav-item[data-status="pending"] .side-nav-count{ color:var(--status-pending-strong); }
+    .side-nav-item[data-status="pending"] .side-nav-link,
+    .side-nav-item[data-status="pending"] .side-nav-count{ color:rgb(var(--status-pending) / 1); }
     .side-nav-item[data-status="optional"]{
-      background:var(--status-optional-bg);
-      border-color:var(--status-optional-border);
+      background:rgb(var(--status-optional) / 0.12);
+      border-color:rgb(var(--status-optional) / 0.35);
     }
-    .side-nav-item[data-status="optional"] .side-nav-link{ color:var(--status-optional-text); }
-    .side-nav-item[data-status="optional"] .side-nav-count{ color:var(--status-optional-strong); }
+    .side-nav-item[data-status="optional"] .side-nav-link,
+    .side-nav-item[data-status="optional"] .side-nav-count{ color:rgb(var(--status-optional) / 1); }
     body[data-side-nav-open="1"]{ overflow:hidden; }
     .side-nav-backdrop{
       position:fixed;
@@ -2436,14 +2375,14 @@
       box-shadow:0 0 0 2px rgba(217,45,32,.2) !important;
     }
     .input-complete{
-      border-color:var(--status-complete-border) !important;
-      box-shadow:0 0 0 2px rgba(34,197,94,.25) !important;
+      border-color:rgb(var(--status-complete) / 0.45) !important;
+      box-shadow:0 0 0 2px rgb(var(--status-complete) / 0.25) !important;
     }
     .basic-info-field[data-state="complete"] label{
-      color:var(--status-complete-strong);
+      color:rgb(var(--status-complete) / 1);
     }
     .basic-info-field[data-state="invalid"] label{
-      color:var(--label);
+      color:rgb(17 17 17 / 0.75);
     }
     .basic-info-status{
       font-size:0.82rem;
@@ -2457,7 +2396,7 @@
     .basic-info-status::before{ content:''; font-weight:700; }
     .basic-info-status[data-state="invalid"]{ color:#b91c1c; }
     .basic-info-status[data-state="invalid"]::before{ content:'!'; }
-    .basic-info-status[data-state="complete"]{ color:var(--status-complete-strong); }
+    .basic-info-status[data-state="complete"]{ color:rgb(var(--status-complete) / 1); }
     .basic-info-status[data-state="complete"]::before{ content:'✓'; }
     .cms-level-row #cmsLevelGroup{
       transition:box-shadow .2s ease;
@@ -2467,11 +2406,11 @@
       border-radius:16px;
     }
     .cms-level-row[data-status="complete"] #cmsLevelGroup{
-      box-shadow:0 0 0 2px rgba(34,197,94,.25);
+      box-shadow:0 0 0 2px rgb(var(--status-complete) / 0.25);
       border-radius:16px;
     }
-    .cms-level-row[data-status="complete"] > .h3{ color:var(--status-complete-strong); }
-    .cms-level-row[data-status="invalid"] > .h3{ color:var(--label); }
+    .cms-level-row[data-status="complete"] > .h3{ color:rgb(var(--status-complete) / 1); }
+    .cms-level-row[data-status="invalid"] > .h3{ color:rgb(17 17 17 / 0.75); }
     .group[data-plan-locked="1"] .group-header{ opacity:.85; }
     .group[data-plan-locked="1"] .group-collapse{
       cursor:not-allowed;
@@ -2515,15 +2454,15 @@
     /* === Section card 通用網格與工具類 === */
     .section-card-grid{
       display:grid;
-      gap:var(--gap, 12px);
-      grid-template-columns:repeat(auto-fit, minmax(280px, 1fr));
+      gap:var(--space-sm);
+      grid-template-columns:repeat(auto-fit, minmax(280px, min(50%, 1fr)));
       align-items:start;
     }
     
     .section-card{
       display:flex;
       flex-direction:column;
-      gap:var(--gap, 12px);
+      gap:var(--space-sm);
       break-inside:avoid;
       -webkit-column-break-inside:avoid;
       page-break-inside:avoid;
@@ -2540,12 +2479,12 @@
     }
     .autogrid{
       display:grid;
-      gap:var(--gap, 12px);
+      gap:var(--autogrid-gap, var(--space-sm));
       grid-template-columns:repeat(auto-fit, minmax(var(--col-min, 280px), 1fr));
       align-items:start;
     }
-    .autogrid--tight{ --gap:8px; --col-min:240px; }
-    .autogrid--wide{ --gap:16px; --col-min:320px; }
+    .autogrid--tight{ --autogrid-gap:var(--space-xs); --col-min:240px; }
+    .autogrid--wide{ --autogrid-gap:var(--space-md); --col-min:320px; }
     .span-2{ grid-column:span 2; }
     .span-3{ grid-column:span 3; }
     


### PR DESCRIPTION
## Summary
- consolidate the root color, spacing, and typography tokens to the minimal set and update component styling to use them
- refresh heading, form, and navigation colors and spacing so they derive from the streamlined tokens
- adjust responsive layouts so page sections only render one or two columns and card grids cap at two columns

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d509b05c2c832ba35c0ed0027269d0