### PR TITLE
Refine sidebar styling and scheduling pipeline

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -21,51 +21,49 @@
     */
 
     :root{
-      --bg:#ffffff;
-      --card:#ffffff;
-      --text:#111111;
-      --border:#dfe3ea;
+      --color-theme:#0B57D0;
+      --color-state-complete:#047857;
+      --color-state-partial:#B45309;
+      --color-state-pending:#1F2937;
+      --color-state-optional:#64748B;
 
-      --accent:#0B57D0;
-      --accent-weak:rgba(11,87,208,.12);
+      --space-1:4px;
+      --space-2:8px;
+      --space-3:12px;
+      --space-4:16px;
+      --space-5:24px;
 
-      --status-complete:4 120 87;
-      --status-partial:180 83 9;
-      --status-pending:31 41 55;
-      --status-optional:71 85 105;
+      --font-size-a:1rem;
+      --font-size-aplus:1.18rem;
 
-      --space-xxs:4px;
-      --space-xs:8px;
-      --space-sm:12px;
-      --space-md:16px;
-      --space-lg:24px;
+      --fs-base:var(--font-size-a);
+      --fs-ctrl:1.125rem;
 
-      --fs-base:1rem;
-      --fs-title:clamp(1.25rem, 1.1rem + .35vw, 1.5rem);
-      --fs-ctrl:18px;
+      --space-xxs:var(--space-1);
+      --space-xs:var(--space-2);
+      --space-sm:var(--space-3);
+      --space-md:var(--space-4);
+      --space-lg:var(--space-5);
 
-      --radius:10px;
-      --shadow:0 10px 30px rgba(15,23,42,.08);
-      --ctrl-padding-block:var(--space-xs);
-      --ctrl-padding-inline:var(--space-sm);
-      --button-padding-inline:var(--space-md);
-      --button-small-padding-inline:var(--space-sm);
+      --ctrl-padding-block:var(--space-2);
+      --ctrl-padding-inline:var(--space-3);
+      --button-padding-inline:var(--space-4);
+      --button-small-padding-inline:var(--space-3);
       --button-padding-block:calc(var(--ctrl-padding-block) - 1px);
       --button-padding-block-sm:calc(var(--ctrl-padding-block) - 3px);
       --h-input:calc(var(--fs-ctrl) + 2 * var(--ctrl-padding-block));
       --h-button:calc(var(--fs-ctrl) + 2 * var(--button-padding-block));
       --h-button-sm:calc(var(--fs-ctrl) + 2 * var(--button-padding-block-sm));
-      --checkbox:calc(var(--space-lg) + var(--space-xxs));
+      --checkbox:calc(var(--space-5) + var(--space-2));
       --fab-h:0px;
       --fab-gap:calc(max(20px, env(safe-area-inset-bottom) + 20px));
       --app-top-offset:0px;
       --side-nav-w:280px;
-      --sticky-padding-block:var(--space-xs);
+      --sticky-padding-block:var(--space-2);
       --sticky-padding-inline:clamp(10px, 3.2vw, 18px);
       --wizard-index-size:34px;
       --wizard-index-font:0.95rem;
-      --group-header-spacing:var(--space-xs);
-      --bottom-bar-min-height:48px;
+      --group-header-spacing:var(--space-2);
       --layout-max:1440px;
       --section-col-min:340px;
       --section-col-max:560px;
@@ -92,9 +90,8 @@
       .app-sticky-inner{ padding:var(--space-xs) var(--space-sm); gap:var(--space-xs); border-radius:14px; }
       .sticky-header-row{ flex-direction:column; align-items:flex-start; }
       .sticky-controls{ width:100%; justify-content:flex-start; }
-      .sticky-summary{ flex-direction:column; align-items:flex-start; gap:var(--space-xs); }
-      .summary-item{ flex-direction:row; }
-      .summary-value{ font-size:1.05rem; }
+      .sticky-summary{ flex-wrap:wrap; align-items:flex-start; gap:var(--space-2); }
+      .summary-progress-bar{ width:160px; }
 
       .wizard{
         overflow-x:auto;
@@ -163,23 +160,26 @@
       .extras-heading-grid{ grid-template-columns:1fr; }
     
       .side-nav{
-        right:max(var(--space-sm), env(safe-area-inset-right) + var(--space-sm));
-        bottom:max(var(--space-md), env(safe-area-inset-bottom) + var(--space-md));
+        position:fixed;
+        top:var(--space-4);
+        right:var(--space-4);
         left:auto;
         width:min(92vw, 320px);
-        transform:translateX(calc(100% + var(--space-md)));
-        opacity:0;
-        pointer-events:none;
-        transition:transform .3s ease, opacity .3s ease;
+        max-height:calc(100vh - 2 * var(--space-4));
+        overflow:auto;
+        background:#ffffff;
+        border:1px solid #d7dce4;
+        border-radius:12px;
+        padding:var(--space-3);
+        display:none;
+        z-index:1200;
       }
       body[data-side-nav-open="1"] .side-nav{
-        transform:translateX(0);
-        opacity:1;
-        pointer-events:auto;
+        display:block;
       }
       .side-nav-trigger{
         display:inline-flex;
-        margin:var(--space-sm) 0 var(--space-xs);
+        margin:var(--space-3) 0 var(--space-2);
       }
     
       #wizardPrevBtn{ display:none; }
@@ -329,1853 +329,55 @@
     
       .plan-summary-totals{ grid-template-columns:repeat(3, minmax(0, 1fr)); }
     
-      .side-nav-backdrop{ display:none; }
-      .side-nav-trigger{ display:none !important; }
-      body[data-side-nav-open]{ overflow:auto; }
-    
-      .side-nav{ width:var(--side-nav-w); }
-    
-    }
-
-    
-
-    html, body{ background:var(--bg); color:var(--text); }
-    body{
-      font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans TC", Arial, sans-serif;
-      font-size:var(--fs-base);
-      line-height:1.65;
-      letter-spacing:.2px;
-      margin:clamp(var(--space-xs), 4vw, var(--space-md));
-      -webkit-tap-highlight-color:transparent;
-      text-rendering:optimizeLegibility;
-    }
-
-    .sr-only{
-      position:absolute;
-      width:1px;
-      height:1px;
-      padding:0;
-      margin:-1px;
-      overflow:hidden;
-      clip:rect(0 0 0 0);
-      white-space:nowrap;
-      border:0;
-    }
-    body[data-fontscale="sm"]{
-      --fs-ctrl:20px;
-      --checkbox:calc(var(--space-lg) + var(--space-xxs));
-      line-height:1.7;
-    }
-    body[data-fontscale="xl"]{
-      font-size:calc(var(--fs-base) * 1.15);
-      --fs-ctrl:24px;
-      --ctrl-padding-block:var(--space-sm);
-      --ctrl-padding-inline:var(--space-md);
-      --button-padding-inline:var(--space-lg);
-      --button-small-padding-inline:var(--space-md);
-      --checkbox:calc(var(--space-lg) + var(--space-sm));
-      line-height:1.78;
-    }
-    body[data-uimode="comfort"] .group,
-    body[data-uimode="comfort"] .section-card{ padding:var(--space-md); }
-    body[data-uimode="comfort"] .app-main,
-    body[data-uimode="comfort"] .page-section[data-active="1"]{ gap:var(--space-lg); }
-    body[data-vertical-density="compact"]{
-      line-height:1.55;
-    }
-    body[data-vertical-density="compact"] .group,
-    body[data-vertical-density="compact"] .section-card{ padding:var(--space-xs); }
-    body[data-vertical-density="compact"] .app-main,
-    body[data-vertical-density="compact"] .page-section[data-active="1"]{ gap:var(--space-sm); }
-    .app-container{
-      width:100%;
-      margin:0 auto;
-      padding-top:var(--space-xs);
-      padding-top:calc(var(--space-xs) + constant(safe-area-inset-top));
-      padding-top:calc(var(--space-xs) + env(safe-area-inset-top));
-      padding-bottom:calc(var(--fab-h, 0px) + var(--space-md));
-      box-sizing:border-box;
-    }
-    .page{
-      width:min(1360px, 100%);
-      margin-inline:auto;
-      padding-inline:clamp(12px, 4vw, 24px);
-      box-sizing:border-box;
-    }
-    .app-shell{
-      width:100%;
-      display:flex;
-      flex-direction:column;
-      gap:clamp(var(--space-lg), 4vw, calc(var(--space-lg) * 1.5));
-    }
-    .app-header{
-      position:relative;
-      z-index:20;
-    }
-    .app-body{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-sm);
-      position:relative;
-    }
-    .app-body-controls{
-      display:flex;
-      justify-content:flex-end;
-      padding-inline:clamp(12px, 4vw, 24px);
-    }
-    .app-main{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-md);
-      padding-inline:clamp(12px, 4vw, 24px);
-      box-sizing:border-box;
-    }
-    
-    
-
-    /* 卡片 */
-    .group,
-    .section-card{
-      background:var(--card);
-      border:1px solid var(--border);
-      border-radius:var(--radius);
-      padding:var(--space-sm);
-      box-shadow:var(--shadow);
-      width:100%;
-      box-sizing:border-box;
-    }
-    .group.card-main,
-    .group.card-lg{
-      display:block;
-    }
-    .group-header{
-      display:flex;
-      align-items:center;
-      justify-content:space-between;
-      gap:var(--group-header-spacing);
-      margin-bottom:var(--space-xs);
-      flex-wrap:wrap;
-    }
-    .group-header > .titlebar{
-      flex:1 1 auto;
-      margin:0;
-    }
-    .group[data-collapsed="1"] .group-header{ margin-bottom:0; }
-    .group-content{ display:block; }
-    .group[data-collapsed="1"] .group-content{ display:none; }
-    .group-collapse{
-      border:none;
-      background:rgba(11,87,208,.08);
-      color:var(--accent);
-      font-weight:600;
-      font-size:0.9rem;
-      padding:6px 12px;
-      border-radius:999px;
-      cursor:pointer;
-      display:inline-flex;
-      align-items:center;
-      gap:4px;
-      transition:background .2s ease, color .2s ease;
-    }
-    .group-collapse:hover,
-    .group-collapse:focus-visible{
-      background:rgba(11,87,208,.16);
-      outline:none;
-    }
-    .group-collapse-icon{ display:inline-block; transition:transform .2s ease; }
-    .group[data-collapsed="1"] .group-collapse-icon{ transform:rotate(-90deg); }
-    body[data-uimode="review"] .group{ border-radius:8px; }
-    /* 交錯輕底以分區（依 page-section 容器交錯） */
-    .page-section[data-active="1"] > .group:nth-of-type(odd){ background:rgb(11 87 208 / 0.04); }
-
-    /* 標題列與標題字（以 H 系列為主） */
-    .titlebar{
-      display:grid;
-      grid-template-columns:minmax(0, 1fr) auto;
-      align-items:center;
-      gap:var(--space-xs);
-      row-gap:var(--space-xxs);
-      margin:0 0 var(--space-xs);
-    }
-    
-    .titlebar--mt-xxs{ margin-top:var(--space-xxs); }
-    .titlebar--mt-xs{ margin-top:var(--space-xs); }
-    .titlebar--mt-sm{ margin-top:var(--space-sm); }
-    .titlebar--mt-md{ margin-top:var(--space-md); }
-
-    /* ===== Headings System (H1–H6) ===== */
-    .h1{
-      display:block;
-      font-weight:800;
-      color:rgb(17 17 17 / 0.95);
-      font-size:clamp(26px, 2.5vw, 34px);
-      margin-top:calc(var(--space-lg) + var(--space-md));
-      margin-bottom:var(--space-lg);
-      padding-bottom:6px;
-      border-bottom:2px solid var(--accent);
-    }
-    .h2{
-      display:block;
-      font-weight:800;
-      color:rgb(17 17 17 / 0.9);
-      font-size:clamp(21px, 2.2vw, 28px);
-      margin-top:calc(var(--space-lg) + var(--space-xs));
-      margin-bottom:var(--space-md);
-      padding-left:14px;
-      border-left:5px solid var(--accent);
-      border-bottom:none !important;
-      letter-spacing:.01em;
-    }
-    .h3{
-      display:block;
-      font-weight:600;
-      color:rgb(17 17 17 / 0.85);
-      font-size:clamp(19px, 1.75vw, 23px);
-      margin-top:var(--space-lg);
-      margin-bottom:var(--space-sm);
-      padding-bottom:6px;
-      border-bottom:1px solid rgb(17 17 17 / 0.12);
-      letter-spacing:.005em;
-    }
-    .h4{
-      display:block;
-      font-weight:500;
-      color:rgb(17 17 17 / 0.75);
-      font-size:16px;
-      margin-top:var(--space-md);
-      margin-bottom:var(--space-xs);
-      padding:var(--space-xxs) var(--space-xs);
-      background:#F9FAFB;
-      border-radius:8px;
-    }
-    /* 段落（H5對應） */
-    .paragraph{ font-size:16px; font-weight:400; color:#111827; line-height:1.5; }
-    .h5{ font-size:16px; font-weight:400; color:#111827; line-height:1.5; }
-
-    .heading-tier{ display:block; font-weight:700; }
-    .h2.heading-tier,
-    .h3.heading-tier,
-    .h4.heading-tier,
-    .h5.heading-tier{ border-left:none; border-bottom:none; padding-left:0; background:none; }
-    .heading-tier--primary{
-      color:rgb(17 17 17 / 0.9);
-      font-size:clamp(22px, 1.9vw, 28px);
-      margin-top:calc(var(--space-lg) + var(--space-xs));
-      margin-bottom:var(--space-md);
-      padding-bottom:6px;
-      border-bottom:1px solid var(--border);
-    }
-    .heading-tier--section{
-      color:rgb(17 17 17 / 0.85);
-      font-size:clamp(19px, 1.6vw, 23px);
-      margin-top:var(--space-lg);
-      margin-bottom:var(--space-sm);
-      border-left:4px solid var(--accent);
-      padding-left:12px;
-      border-radius:4px;
-    }
-    .heading-tier--subsection{
-      color:rgb(17 17 17 / 0.7);
-      font-size:18px;
-      margin-top:var(--space-md);
-      margin-bottom:var(--space-xs);
-    }
-    /* 佈局：桌機固定兩欄、行動單欄（避免三欄造成橫向拉長） */
-    [data-section],
-    .page-section,
-    .group{
-      scroll-margin-top:var(--app-top-offset);
-    }
-    .row{ display:flex; gap:var(--space-sm); flex-wrap:wrap; align-items:flex-start; margin-bottom:var(--space-xs); }
-    .row > div{ flex:1 1 min(100%, 360px); min-width:min(100%, 240px); max-width:720px; }
-    .row > [data-field-size="short"],
-    .section-group-body > [data-field-size="short"]{
-      flex:1 1 calc(33.333% - var(--space-sm));
-      min-width:180px;
-    }
-    .row > [data-field-size="medium"],
-    .section-group-body > [data-field-size="medium"]{
-      flex:1 1 calc(50% - var(--space-sm));
-      min-width:260px;
-    }
-    .row > [data-field-size="long"],
-    .section-group-body > [data-field-size="long"]{
-      flex:1 1 100%;
-      min-width:100%;
-    }
-    
-
-    /* 標籤與 Placeholder（加大字、提升對比） */
-    label{ display:block; font-size:calc(var(--fs-ctrl) - 2px); margin-bottom:var(--space-xxs); color:rgb(17 17 17 / 0.75); }
-    :where(input,select,textarea)::placeholder{ color:rgb(17 17 17 / 0.55); opacity:1; font-size:calc(var(--fs-ctrl) - 2px); }
-    :where(input,select,textarea,button,.datebox){ scroll-margin-top:calc(var(--app-top-offset) + var(--space-md)); }
-
-    /* 表單元件：20px 字級，56px 高度（iOS 聚焦不縮放） */
-    input[type="text"], input[type="number"], input[type="tel"], input[type="email"],
-    input[type="search"], input[type="date"], input[type="time"],
-    select, textarea{
-      width:100%; box-sizing:border-box;
-      min-height:var(--h-input);
-      padding:var(--ctrl-padding-block) var(--ctrl-padding-inline);
-      font-size:var(--fs-ctrl);
-      line-height:1.45;
-      background:#fff;
-      border:1px solid var(--border);
-      border-radius:10px;
-      transition:border-color .15s ease, box-shadow .15s ease, background-color .15s ease;
-      appearance:none;
-    }
-    textarea{ min-height:var(--textarea-min); height:auto; resize:vertical; }
-
-    /* Focus 樣式：清楚但不刺眼 */
-    input:focus, select:focus, textarea:focus{
-      outline:none;
-      border-color:var(--accent);
-      box-shadow:0 0 0 3px var(--accent-weak);
-    }
-
-    /* 禁用狀態：底色與字色明顯區隔 */
-    input:disabled, select:disabled, textarea:disabled{
-      background:#f3f5f7; color:#777; border-color:#e1e5ea;
-    }
-
-    /* 日期顯示盒（更清楚） */
-    .datebox{
-      display:block;
-      width:100%;
-    }
-    .datebox input[type="date"]{
-      width:100%;
-      min-width:0;
-      padding-right:var(--ctrl-padding-inline);
-    }
-
-    /* 按鈕與操作面積（以 padding 控制高度） */
-    .btnbar{ display:flex; gap:8px; flex-wrap:wrap; margin-top:var(--space-xs); }
-    button{
-      min-height:var(--h-button);
-      padding:var(--button-padding-block) var(--button-padding-inline);
-      border-radius:10px;
-      border:1px solid var(--border);
-      background:#fff; color:#111; font-weight:700; cursor:pointer;
-      line-height:1.1; touch-action:manipulation; font-size:var(--fs-ctrl);
-    }
-    button:hover{ background:#f7f7f7; }
-    button.primary{ background:var(--accent); color:#fff; border-color:var(--accent); }
-    button.button-add,
-    button[data-variant="add"]{
-      background:var(--accent);
-      color:#fff;
-      border-color:var(--accent);
-      box-shadow:none;
-    }
-    button.button-add:hover,
-    button[data-variant="add"]:hover{
-      background:#0a4dc2;
-      border-color:#0a4dc2;
-    }
-    button.small{
-      min-height:max(var(--h-button-sm), 44px);
-      min-width:56px;
-      padding:calc(var(--button-padding-block-sm) + 2px) var(--button-small-padding-inline);
-      font-size:var(--fs-ctrl);
-    }
-    /* 可選：若於按鈕加入 data-ic="plus"/"minus"，會自動加上 + / - 圖示 */
-    button[data-ic="plus"]::before{ content:"+"; margin-right:.25em; font-weight:900; }
-    button[data-ic="minus"]::before{ content:"–"; margin-right:.25em; font-weight:900; }
-
-    .app-sticky{
-      position:sticky;
-      top:0;
-      z-index:1000;
-      padding:var(--sticky-padding-block) var(--sticky-padding-inline);
-      margin-bottom:var(--space-md);
-    }
-    .app-sticky-inner{
-      width:min(1360px, 100%);
-      margin:0 auto;
-      background:rgba(255,255,255,.94);
-      border:1px solid var(--border);
-      border-radius:16px;
-      box-shadow:var(--shadow);
-      padding:var(--space-xs) var(--space-sm);
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-sm);
-      backdrop-filter:saturate(180%) blur(6px);
-      -webkit-backdrop-filter:saturate(180%) blur(6px);
-    }
-    .sticky-header{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-sm);
-    }
-    .sticky-header-row{
-      display:flex;
-      flex-wrap:wrap;
-      align-items:center;
-      justify-content:space-between;
-      gap:var(--space-sm);
-    }
-    .sticky-controls{
-      display:flex;
-      flex-wrap:wrap;
-      align-items:center;
-      justify-content:flex-end;
-      gap:var(--space-sm);
-    }
-    .wizard-quickjump{
-      display:flex;
-      align-items:center;
-      gap:var(--space-xxs);
-    }
-    .wizard-quickjump label{
-      font-weight:600;
-      color:rgb(17 17 17 / 0.75);
-      font-size:0.95rem;
-    }
-    .sticky-summary{
-      display:flex;
-      flex-wrap:wrap;
-      align-items:center;
-      gap:var(--space-sm);
-    }
-    .summary-item{
-      display:flex;
-      align-items:center;
-      gap:var(--space-xxs);
-      min-width:0;
-    }
-    .summary-item.summary-progress{ flex-wrap:wrap; }
-    .summary-label{ font-size:0.85rem; color:#475569; font-weight:600; }
-    .summary-value{ font-size:1.05rem; font-weight:700; color:rgb(17 17 17 / 0.9); word-break:break-word; }
-    .summary-progress-bar{ position:relative; height:10px; border-radius:999px; background:#e2e8f0; overflow:hidden; min-width:120px; }
-    .summary-progress-fill{ position:absolute; inset:0; width:0%; border-radius:999px; background:var(--accent); transition:width .3s ease; }
-    .summary-progress-text,
-    .summary-remaining-text{ font-weight:600; color:#475569; font-size:0.95rem; }
-    .font-scale-control{
-      display:inline-flex;
-      align-items:center;
-      gap:4px;
-      padding:4px;
-      border-radius:999px;
-      border:1px solid var(--border);
-      background:#fff;
-      box-shadow:none;
-    }
-    .font-scale-control button{
-      min-width:38px;
-      min-height:calc(var(--h-button-sm) - 2px);
-      padding:var(--button-padding-block-sm) 12px;
-      border:none;
-      border-radius:999px;
-      background:transparent;
-      font-weight:600;
-      font-size:0.95rem;
-      color:var(--accent);
-      cursor:pointer;
-      transition:background .2s ease, color .2s ease;
-    }
-    .font-scale-control button[data-active="1"]{
-      background:var(--accent);
-      color:#fff;
-    }
-    .font-scale-control button:focus-visible{
-      outline:2px solid var(--accent);
-      outline-offset:2px;
-    }
-    .wizard-quickjump label{
-      font-size:0.85rem;
-      font-weight:600;
-      color:#475569;
-    }
-    .wizard-quickjump select{
-      min-height:var(--h-button-sm);
-      padding:var(--button-padding-block-sm) var(--button-small-padding-inline);
-      border-radius:10px;
-      border:1px solid var(--border);
-      background:#fff;
-      color:rgb(17 17 17 / 0.75);
-      font-size:var(--fs-ctrl);
-    }
-    .wizard-quickjump select:focus{
-      outline:none;
-      border-color:var(--accent);
-      box-shadow:0 0 0 3px var(--accent-weak);
-    }
-    
-    .page-tabs{ display:flex; flex-wrap:wrap; gap:var(--space-xs); margin:0; }
-    .page-tabs button{
-      min-height:var(--h-button-sm);
-      padding:var(--button-padding-block-sm) var(--button-small-padding-inline);
-      border-radius:999px;
-      border:1px solid var(--border);
-      background:#fff;
-      color:rgb(17 17 17 / 0.75);
-      font-weight:600;
-      cursor:pointer;
-      transition:background .15s ease, color .15s ease, border-color .15s ease;
-    }
-    .page-tabs button.active{
-      background:var(--accent);
-      color:#fff;
-      border-color:var(--accent);
-    }
-    .wizard{
-      position:relative;
-      display:flex;
-      justify-content:flex-start;
-      align-items:center;
-      gap:var(--space-sm);
-      flex-wrap:wrap;
-    }
-    .wizard-step{
-      position:relative;
-      flex:1 1 160px;
-      display:flex;
-      flex-direction:column;
-      align-items:center;
-      gap:var(--space-xxs);
-      border:none;
-      background:none;
-      cursor:pointer;
-      color:rgb(17 17 17 / 0.75);
-      font-weight:600;
-      padding:var(--space-xxs) var(--space-xs);
-      border-radius:12px;
-      transition:background .2s ease, color .2s ease, box-shadow .2s ease;
-    }
-    .wizard-step[data-locked="1"]{
-      opacity:.55;
-      cursor:not-allowed;
-    }
-    .wizard-step[data-locked="1"]:hover{
-      background:none;
-      color:rgb(17 17 17 / 0.75);
-    }
-    .wizard-step::before{
-      content:'';
-      position:absolute;
-      top:calc(var(--wizard-index-size) / 2);
-      left:-50%;
-      width:100%;
-      height:4px;
-      background:#dbe5ff;
-      z-index:-1;
-      transform:translateY(-50%);
-    }
-    .wizard-step:first-child::before{ display:none; }
-    .wizard-step[data-status="done"]::before,
-    .wizard-step[data-status="active"]::before{
-      background:var(--accent);
-    }
-    .wizard-step:focus-visible{
-      outline:2px solid var(--accent);
-      outline-offset:4px;
-    }
-    .wizard-index{
-      width:var(--wizard-index-size);
-      height:var(--wizard-index-size);
-      border-radius:50%;
-      display:flex;
-      align-items:center;
-      justify-content:center;
-      background:#e2e8f0;
-      color:#1f2937;
-      font-weight:800;
-      font-size:var(--wizard-index-font);
-      transition:background .2s ease, color .2s ease, transform .2s ease;
-    }
-    .wizard-label{
-      font-size:0.9rem;
-      text-align:center;
-      line-height:1.4;
-    }
-    .wizard-step:hover{
-      background:rgba(11,87,208,.06);
-      color:var(--accent);
-    }
-    .wizard-step[data-status="active"] .wizard-index,
-    .wizard-step[data-status="done"] .wizard-index{
-      background:var(--accent);
-      color:#fff;
-    }
-    .wizard-step[data-status="active"]{
-      background:rgba(11,87,208,.12);
-      box-shadow:0 0 0 1px rgba(11,87,208,.18);
-    }
-    .wizard-step[data-status="active"] .wizard-index{
-      transform:scale(1.05);
-    }
-    .wizard-step[data-status="active"] .wizard-label{ color:var(--accent); }
-    .wizard-step[data-status="done"] .wizard-label{ color:rgb(var(--status-complete) / 1); }
-    
-    .page-section{
-      display:none;
-      width:100%;
-      container-type:inline-size;
-      container-name:page-section;
-    }
-    .page-section[data-columns="1"]{
-      --section-col-min:100%;
-      --section-col-max:100%;
-      --section-col-preferred:100%;
-    }
-    .page-section[data-active="1"]{
-      display:flex;
-      flex-wrap:wrap;
-      gap:var(--space-md);
-      align-items:stretch;
-      justify-content:flex-start;
-      margin-bottom:var(--space-lg);
-    }
-    .page-section[data-columns="1"][data-active="1"]{
-      flex-direction:column;
-    }
-    .page-section[data-active="1"] > .group{
-      flex:1 1 clamp(var(--section-col-min), var(--section-col-preferred), var(--section-col-max));
-      min-width:min(100%, var(--section-col-min));
-    }
-    .page-section[data-active="1"] > .group[data-span="full"]{
-      flex:1 1 100%;
-      min-width:100%;
-    }
-
-    @container page-section (min-width:900px) and (max-width:1200px){
-      .page-section[data-columns="2"][data-active="1"]{
-        display:grid;
-        grid-template-columns:minmax(var(--section-col-min), .4fr) minmax(var(--section-col-min), .6fr);
-        align-items:start;
-        gap:var(--space-md);
+      .side-nav-backdrop{
+        position:fixed;
+        inset:0;
+        background:rgba(17,17,17,0.35);
+        opacity:0;
+        pointer-events:none;
+        z-index:1100;
       }
-      .page-section[data-columns="2"][data-active="1"] > .group{
-        min-width:0;
-        width:100%;
+      body[data-side-nav-open="1"] .side-nav-backdrop{
+        opacity:1;
+        pointer-events:auto;
       }
-      .page-section[data-columns="2"][data-active="1"] > .group[data-span="full"],
-      .page-section[data-columns="2"][data-active="1"] > .section-intro-grid{
-        grid-column:1 / -1;
+      .side-nav-trigger{
+        display:none;
+        align-items:center;
+        justify-content:center;
+        gap:8px;
+        padding:8px 14px;
+        border:1px solid #d7dce4;
+        border-radius:999px;
+        background:#ffffff;
+        color:#111111;
+        font-weight:600;
+        cursor:pointer;
       }
-    }
-
-    .summary-title{ font-weight:700; color:rgb(17 17 17 / 0.9); margin-bottom:8px; }
-    .summary-actions{
-      display:flex;
-      justify-content:flex-end;
-      align-items:center;
-      gap:8px;
-      margin-bottom:8px;
-      flex-wrap:wrap;
-    }
-    .summary-table-wrapper{
-      overflow:auto;
-      max-height:clamp(280px, 48vh, 520px);
-    }
-    .summary-table{ width:100%; border-collapse:collapse; min-width:600px; }
-    .summary-table th, .summary-table td{
-      border:1px solid var(--border);
-      padding:var(--space-xs) var(--space-sm);
-      text-align:left;
-      vertical-align:top;
-    }
-    .summary-table th{ background:#eef2ff; color:#1f2937; font-weight:700; }
-    .summary-table thead{ position:sticky; top:0; z-index:1; }
-    .summary-table thead th{
-      position:sticky;
-      top:0;
-      z-index:2;
-      background:#eef2ff;
-      box-shadow:0 2px 0 rgba(148,163,184,.18);
-    }
-
-    .cms-level-group{
-      display:grid;
-      gap:var(--space-xs);
-      grid-template-columns:repeat(auto-fit, minmax(64px, 1fr));
-      align-items:stretch;
-    }
-    
-    .cms-level-group button{
-      min-width:0;
-      min-height:48px;
-      padding:0 12px;
-      border-radius:999px;
-      font-size:var(--fs-ctrl);
-      line-height:1;
-      display:flex;
-      align-items:center;
-      justify-content:center;
-    }
-    .cms-level-group button[data-active="1"]{
-      background:var(--accent);
-      color:#fff;
-      border-color:var(--accent);
-    }
-
-    #basicInfoGroup .basic-info-fields{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-xs);
-    }
-    #basicInfoGroup .basic-info-row{
-      display:flex;
-      flex-wrap:wrap;
-      gap:var(--space-sm);
-      align-items:flex-start;
-    }
-    #basicInfoGroup .basic-info-field{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-xxs);
-      min-width:0;
-    }
-    #basicInfoGroup .basic-info-field label{ margin-bottom:0; }
-    #basicInfoGroup .unit-code-field{
-      /* 與其他欄位一致寬度 */
-      flex:0 0 var(--intro-colw);
-      max-width:var(--intro-colw);
-    }
-    #basicInfoGroup .unit-code-field select{
-      width:100%;
-      min-width:0;
-    }
-    #basicInfoGroup .case-manager-field{
-      flex:0 0 var(--intro-colw);
-      max-width:var(--intro-colw);
-      min-width:0;
-      overflow:hidden;
-    }
-    #basicInfoGroup .case-name-field,
-    #basicInfoGroup .consult-name-field{
-      flex:0 0 var(--intro-colw);
-      max-width:var(--intro-colw);
-      min-width:0;
-    }
-    #basicInfoGroup .case-manager-field input,
-    #basicInfoGroup .case-manager-field select,
-    #basicInfoGroup .case-name-field input,
-    #basicInfoGroup .consult-name-field select{
-      width:100%;
-      max-width:100%;
-      white-space:nowrap;
-      overflow:hidden;
-      text-overflow:ellipsis;
-    }
-    
-    #basicInfoGroup .cms-level-row{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-xs);
-      margin-top:var(--space-xxs);
-    }
-    #contactVisitGroup .contact-visit-cards{
-      display:grid;
-      gap:var(--space-sm);
-    }
-    
-    #contactVisitGroup .contact-visit-card{
-      border:1px solid var(--border);
-      border-radius:var(--radius);
-      padding:var(--space-sm);
-      background:#fff;
-      box-shadow:inset 0 1px 0 rgba(255,255,255,.6);
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-xs);
-    }
-    #contactVisitGroup .contact-visit-card-header{
-      display:flex;
-      align-items:center;
-      justify-content:space-between;
-      gap:var(--space-xs);
-    }
-    #contactVisitGroup .contact-visit-card-body{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-xs);
-    }
-    #contactVisitGroup .contact-visit-card .datebox{
-      width:100%;
-      max-width:100%;
-    }
-    #contactVisitGroup .contact-visit-card .inline-checkbox{
-      margin:0;
-    }
-    #contactVisitGroup .plan-card-case-overview,
-    #contactVisitGroup .plan-card-care-goals,
-    #contactVisitGroup .plan-card-mismatch{
-      grid-column:1 / -1;
-    }
-    #visitPartnersCard{
-      position:relative;
-    }
-    #visitPartnersCard .extra-row{
-      display:flex;
-      flex-wrap:wrap;
-      gap:var(--space-sm);
-      align-items:flex-start;
-      margin-top:var(--space-xs);
-    }
-    #visitPartnersCard .extra-row .field-intro{
-      flex:0 0 var(--intro-colw);
-      max-width:var(--intro-colw);
-    }
-    
-    #visitPartnersCard .extra-row-actions{
-      display:flex;
-      align-items:center;
-      justify-content:center;
-      flex:0 0 auto;
-    }
-    #visitPartnersCard .extra-remove{
-      width:42px;
-      height:42px;
-      border-radius:999px;
-      border:1px solid var(--border);
-      background:rgba(15,23,42,.04);
-      display:flex;
-      align-items:center;
-      justify-content:center;
-      font-size:1.1rem;
-      line-height:1;
-      cursor:pointer;
-      color:#4b5563;
-      transition:background .15s ease, border-color .15s ease, color .15s ease;
-    }
-    #visitPartnersCard .extra-remove:hover,
-    #visitPartnersCard .extra-remove:focus{
-      background:rgba(11,87,208,.12);
-      border-color:var(--accent);
-      color:var(--accent);
-      outline:none;
-    }
-    #visitPartnersCard .extra-remove span{ pointer-events:none; }
-    #extras_conflict{
-      position:absolute;
-      top:var(--space-sm);
-      right:var(--space-sm);
-      max-width:calc(100% - 2 * var(--space-sm));
-      padding:10px 12px;
-      border-radius:10px;
-      border:1px solid #facc15;
-      background:#fef9c3;
-      color:#854d0e;
-      font-size:0.9rem;
-      line-height:1.5;
-      box-shadow:0 4px 12px rgba(250,204,21,.18);
-      display:none;
-      z-index:2;
-    }
-    #extras_conflict[data-show="1"]{ display:block; }
-    #visitPartnersCard[data-conflict="1"]{
-      background:linear-gradient(0deg, rgba(254,249,195,.55), rgba(254,249,195,.55)), var(--card);
-      border-color:#facc15;
-    }
-    #basicInfoGroup input[type="text"],
-    #basicInfoGroup input[type="search"],
-    #basicInfoGroup select{
-      min-height:52px;
-      font-size:var(--fs-ctrl);
-    }
-    #basicInfoGroup input[type="search"],
-    #basicInfoGroup select{
-      white-space:nowrap;
-      overflow:hidden;
-      text-overflow:ellipsis;
-    }
-    #basicInfoGroup input[type="search"]::-webkit-search-cancel-button{
-      cursor:pointer;
-    }
-    
-    
-
-    .location-toolbar{
-      display:flex;
-      align-items:center;
-      justify-content:space-between;
-      margin:12px 0 8px;
-      gap:var(--space-sm);
-      flex-wrap:wrap;
-    }
-    .location-toolbar .location-current{ font-weight:600; color:rgb(17 17 17 / 0.75); }
-    .location-toolbar .location-actions{ display:flex; gap:8px; flex-wrap:wrap; }
-    .location-switch button[data-active="1"],
-    .location-actions button[data-active="1"]{
-      background:var(--accent);
-      color:#fff;
-      border-color:var(--accent);
-    }
-
-    .section-controls{
-      display:flex;
-      flex-wrap:wrap;
-      align-items:center;
-      gap:8px;
-    }
-    .section-controls button{
-      min-height:var(--h-button-sm);
-      padding:var(--button-padding-block-sm) var(--button-small-padding-inline);
-      border-radius:999px;
-      border:1px solid var(--border);
-      background:#fff;
-      color:rgb(17 17 17 / 0.75);
-      font-weight:600;
-      font-size:calc(var(--fs-ctrl) - 2px);
-      cursor:pointer;
-      transition:background .15s ease, color .15s ease, border-color .15s ease;
-    }
-    .section-controls button.active{
-      background:var(--accent);
-      color:#fff;
-      border-color:var(--accent);
-    }
-    .section-controls button.section-toggle-all{
-      background:#f7f9fc;
-    }
-    .section-advanced-count{
-      margin-left:auto;
-      font-size:0.85rem;
-      color:#475569;
-      font-weight:600;
-    }
-    .section-advanced-count[data-hidden="1"]{ display:none; }
-    [data-section][data-show-advanced="0"] .section-advanced-count{
-      color:#b45309;
-    }
-
-    .section-progress{
-      margin:12px 0;
-    }
-    .section-progress-text{
-      font-weight:600;
-      color:rgb(17 17 17 / 0.75);
-      margin-bottom:6px;
-    }
-    .section-progress-bar{
-      position:relative;
-      width:100%;
-      height:8px;
-      border-radius:999px;
-      background:#e5e7eb;
-      overflow:hidden;
-    }
-    .section-progress-bar-fill{
-      position:absolute;
-      inset:0;
-      width:0%;
-      background:var(--accent);
-      transition:width .2s ease;
-    }
-
-    .section-group{
-      border:1px solid var(--border);
-      border-radius:var(--radius);
-      padding:12px;
-      margin-bottom:10px;
-      background:#fff;
-      box-shadow:inset 0 1px 0 rgba(255,255,255,.6);
-    }
-    .section-group[data-level="advanced"]{
-      background:#f8fafc;
-    }
-    .section-group-header{
-      display:flex;
-      align-items:center;
-      justify-content:space-between;
-      gap:8px;
-    }
-    .section-group-toggle{
-      background:none;
-      border:none;
-      padding:0;
-      font-size:1.05rem;
-      font-weight:700;
-      color:var(--accent);
-      cursor:pointer;
-      display:flex;
-      align-items:center;
-      gap:8px;
-      flex:1 1 auto;
-      justify-content:flex-start;
-    }
-    .section-group-toggle::before{
-      content:'▾';
-      font-size:.9rem;
-      color:var(--accent);
-      transition:transform .2s ease;
-    }
-    .section-group[data-collapsed="1"] .section-group-toggle::before{
-      transform:rotate(-90deg);
-    }
-    .section-group[data-level="advanced"] .section-group-toggle,
-    .section-group[data-level="advanced"] .section-group-toggle::before{
-      color:#0b1d4d;
-    }
-    .section-group-progress{ display:none !important; }
-    .section-group-body{
-      margin-top:var(--space-xs);
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-xs);
-    }
-    .section-group[data-collapsed="1"] .section-group-body{
-      display:none;
-    }
-    .section-group-empty{
-      display:none;
-      font-size:.95rem;
-      color:#6b7280;
-      padding:var(--space-xs) var(--space-sm);
-      border-radius:8px;
-      background:#f3f4f6;
-    }
-    .section-group[data-empty="1"] .section-group-empty{
-      display:block;
-    }
-
-    [data-section]{
-      position:relative;
-      display:block;
-    }
-    [data-section][data-hide-filled="1"] [data-field-container][data-filled="1"]{
-      display:none !important;
-    }
-    [data-section][data-show-advanced="0"] .section-group[data-level="advanced"],
-    [data-section][data-show-advanced="0"] [data-field-container][data-level="advanced"]{
-      display:none !important;
-    }
-
-
-    /* 黏底主要動作列（避開 iOS 底部工具列） */
-    .group:last-of-type .btnbar{
-      position:sticky; bottom:max(18px, env(safe-area-inset-bottom));
-      padding:var(--space-sm);
-      background:rgba(255,255,255,.92);
-      border:1px solid var(--border); border-radius:12px; box-shadow:var(--shadow);
-    }
-
-    /* 勾選清單（點擊面積提升） */
-    fieldset.checkcol{ border:0; margin:0; padding:0; min-inline-size:0; }
-    .checkcol{ display:grid; gap:var(--space-xs); grid-template-columns:repeat(auto-fit, minmax(var(--checkcol-min), 1fr)); }
-    
-    .checkcol label{
-      display:flex; align-items:center; gap:var(--space-xs); padding:var(--space-xs) var(--space-sm);
-      border:1px solid var(--border); border-radius:12px; background:#fff; color:#222; font-size:var(--fs-base);
-      margin:0; transition:border-color .2s ease, box-shadow .2s ease, background .2s ease;
-    }
-    .checkcol label::before{ content:''; display:none; }
-    .inline-checkbox{
-      display:inline-flex; align-items:center; gap:var(--space-xxs); font-size:calc(var(--fs-ctrl) - 2px); color:rgb(17 17 17 / 0.75); flex-wrap:wrap;
-    }
-    .inline-checkbox input[type="checkbox"]{ width:calc(var(--checkbox) - 4px); height:calc(var(--checkbox) - 4px); }
-    .checkcol input[type=checkbox]{ width:var(--checkbox); height:var(--checkbox); }
-    .checkcol label[data-auto="1"]{
-      border-color:rgba(11,87,208,.4);
-      background:rgba(11,87,208,.08);
-    }
-
-    /* 需要固定欄寬的首欄位（關係/姓名等） */
-    .field-intro{
-      flex:0 0 var(--intro-colw);
-      max-width:var(--intro-colw);
-      min-width:0;
-      width:var(--intro-colw);
-    }
-    .field-intro-grid{
-      grid-template-columns:minmax(var(--intro-colw), var(--intro-colw)) minmax(var(--intro-colw), var(--intro-colw)) minmax(0, 1fr);
-    }
-    .field-intro select,
-    .field-intro input[type="text"],
-    .field-intro input[type="tel"],
-    .field-intro input[type="number"],
-    .field-intro input[type="email"]{
-      width:100%;
-      max-width:100%;
-      white-space:nowrap;
-      overflow:hidden;
-      text-overflow:ellipsis;
-    }
-    
-
-    .checkcol label[data-auto="1"]::after{
-      content:'（系統預選）';
-      margin-left:8px;
-      color:var(--accent);
-      font-size:.9rem;
-      font-weight:600;
-    }
-    .checkcol label[data-checked="1"],
-    .check-item[data-checked="1"]{
-      border-color:var(--accent);
-      background:rgba(11,87,208,.12);
-      box-shadow:0 0 0 1.5px rgba(11,87,208,.25);
-    }
-    .checkcol label[data-checked="1"]::before,
-    .check-item[data-checked="1"]::before{
-      display:inline-flex;
-      align-items:center;
-      justify-content:center;
-      content:'✓';
-      font-size:.75rem;
-      font-weight:700;
-      color:#fff;
-      background:var(--accent);
-      border-radius:50%;
-      width:1.25em;
-      height:1.25em;
-    }
-     /* 觸控設備放大到 32px */
-    body[data-vertical-density="compact"] .checkcol{ gap:var(--space-xs); }
-    body[data-vertical-density="compact"] .checkcol label{ padding:var(--space-xs) var(--space-sm); }
-
-    .checkcol-wrapper{ display:flex; flex-direction:column; gap:var(--space-xs); }
-    .checkcol-wrapper > .checkcol{ width:100%; }
-    .checkcol-wrapper[data-has-selection="1"] > .checkcol{ border-color:transparent; }
-
-    .virtual-checklist{ position:relative; border:1px solid var(--border); border-radius:var(--radius); background:#fff; }
-    .virtual-checklist-viewport{ position:relative; max-height:320px; overflow-y:auto; }
-    .virtual-checklist-visible{ position:absolute; top:0; left:0; right:0; display:flex; flex-direction:column; }
-    .virtual-checklist-spacer{ height:0; width:1px; }
-    .virtual-checklist-item{ display:flex; align-items:center; gap:var(--space-xs); padding:var(--space-xs) var(--space-sm); border-bottom:1px solid rgba(15,23,42,.08); background:#fff; }
-    .virtual-checklist-item:last-child{ border-bottom:none; }
-    .virtual-checklist-item input[type="checkbox"]{ width:var(--checkbox); height:var(--checkbox); }
-    .virtual-checklist-print{ display:none; margin-top:var(--space-xs); font-size:0.9rem; line-height:1.45; color:#0f172a; }
-    .virtual-checklist-print ol{ margin:var(--space-xxs) 0 0 1.25em; padding-left:1.25em; }
-    .virtual-checklist-print li{ margin-bottom:4px; }
-
-    #careGoals_block{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-md);
-    }
-    #careGoals_block .section-group{
-      margin:0;
-    }
-    #careGoals_block .section-group-body{
-      gap:var(--space-xs);
-    }
-    #careGoals_block .care-goal-block{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-xs);
-    }
-    #careGoals_block .care-goal-heading{
-      display:flex;
-      align-items:center;
-      justify-content:flex-end;
-      gap:var(--space-xs);
-      margin-bottom:var(--space-xs);
-    }
-    #careGoals_block .care-goals-side-inner{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-sm);
-    }
-    #problemCount{
-      display:inline-flex;
-      align-items:center;
-      justify-content:center;
-      padding:4px 12px;
-      border-radius:999px;
-      background:rgba(11,87,208,.12);
-      color:#0b1d4d;
-      font-size:0.9rem;
-      font-weight:700;
-      min-width:0;
-    }
-    .section-selection-badge{
-      display:inline-flex;
-      align-items:center;
-      justify-content:center;
-      padding:4px 12px;
-      border-radius:999px;
-      background:rgba(11,87,208,.12);
-      color:#0b1d4d;
-      font-size:0.9rem;
-      font-weight:600;
-      min-width:0;
-      justify-self:end;
-    }
-    .section-selection-badge[data-hidden="1"]{ display:none; }
-    
-
-    .lesion-mode{ display:flex; gap:8px; flex-wrap:wrap; margin-bottom:8px; }
-    .lesion-mode button.small{ min-width:112px; }
-    .lesion-mode button[data-active="1"]{
-      background:var(--accent);
-      color:#fff;
-      border-color:var(--accent);
-    }
-    .lesion-size-grid{ display:flex; gap:var(--space-sm); flex-wrap:wrap; }
-    .lesion-size-field{ flex:1 1 140px; position:relative; }
-    .lesion-size-field input{ padding-right:42px; }
-    .lesion-size-field .unit{ position:absolute; right:14px; top:50%; transform:translateY(-50%); color:rgb(17 17 17 / 0.75); font-weight:600; pointer-events:none; }
-    .lesion-area{ margin-top:var(--space-xs); font-weight:600; color:rgb(17 17 17 / 0.75); }
-    .action-list{ display:flex; flex-direction:column; gap:var(--space-sm); }
-    .action-item{ border:1px dashed var(--border); border-radius:var(--radius); padding:var(--space-sm); background:#fff; display:flex; flex-direction:column; gap:var(--space-xs); }
-    .action-item-fields{ display:flex; flex-direction:column; gap:var(--space-xs); }
-    .action-item textarea{ resize:vertical; min-height:96px; }
-    .action-item select{ font-size:var(--fs-ctrl); }
-    .action-item-controls{ display:flex; justify-content:flex-end; }
-    .mismatch-diff{ display:flex; flex-wrap:wrap; gap:8px; margin:8px 0; }
-    .mismatch-diff .badge{ background:var(--accent-weak); color:var(--accent); }
-    [data-field-container="1"]{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-xxs);
-      position:relative;
-    }
-    [data-field-container="1"] > label{
-      margin-bottom:0;
-    }
-    .field-error{
-      color:#b3261e;
-      font-size:0.9rem;
-      margin-top:0;
-      align-self:flex-end;
-      text-align:right;
-      display:none;
-      line-height:1.4;
-    }
-    .field-error[data-show="1"]{ display:block; }
-
-    
-
-    .plan-editor{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-md);
-      margin-top:var(--space-sm);
-    }
-    .plan-workspace{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-md);
-      width:100%;
-    }
-    .plan-workspace-main,
-    .plan-workspace-side{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-md);
-    }
-    .plan-workspace-main > .group,
-    .plan-workspace-side > .group{
-      margin:0;
-    }
-    
-    .plan-category{
-      border:1px solid var(--border);
-      border-radius:var(--radius);
-      background:#fff;
-      padding:16px;
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-sm);
-    }
-    .extras-heading-grid{
-      display:grid;
-      grid-template-columns:repeat(auto-fit, minmax(160px, 1fr));
-      gap:var(--space-sm);
-      margin-bottom:var(--space-xs);
-      align-items:end;
-    }
-    
-    .plan-category-heading{
-      display:flex;
-      align-items:center;
-      justify-content:space-between;
-      gap:var(--space-sm);
-    }
-    .plan-category-heading .h3{
-      font-weight:700;
-      color:var(--accent);
-      margin:0;
-    }
-    .plan-category-body{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-sm);
-    }
-    .plan-category-meta{
-      border-style:dashed;
-      background:rgb(11 87 208 / 0.05);
-    }
-    .plan-empty-hint{
-      font-size:0.95rem;
-      color:rgb(17 17 17 / 0.75);
-      padding:var(--space-sm);
-      border:1px dashed var(--border);
-      border-radius:var(--radius);
-      background:#f8fafc;
-    }
-    .plan-entry{
-      border:1px dashed var(--border);
-      border-radius:var(--radius);
-      padding:var(--space-sm);
-      background:rgb(11 87 208 / 0.05);
-    }
-    .plan-entry + .plan-entry{ margin-top:var(--space-sm); }
-    .plan-entry-header{
-      font-weight:700;
-      margin-bottom:var(--space-xs);
-    }
-    .plan-entry-grid{
-      display:grid;
-      grid-template-columns:repeat(auto-fill, minmax(220px, 1fr));
-      gap:var(--space-sm);
-      align-items:start;
-    }
-    .plan-entry-grid textarea,
-    .plan-entry-grid .full{ grid-column:1/-1; }
-    .plan-hint{
-      font-size:0.9rem;
-      color:rgb(17 17 17 / 0.75);
-      opacity:0.85;
-      margin-top:var(--space-xs);
-    }
-    .plan-field.auto-summary .auto-summary-box{
-      padding:12px 16px;
-      border:1px solid var(--border);
-      border-radius:10px;
-      background:#f0f4ff;
-      color:#0b1d4d;
-      font-weight:600;
-      line-height:1.6;
-      box-shadow:inset 0 1px 0 rgba(255,255,255,0.6);
-    }
-    .plan-field.auto-summary .auto-summary-box.empty{
-      color:#4b5563;
-      font-weight:500;
-      background:#f8fafc;
-      border-style:dashed;
-    }
-    .selfpay-field .selfpay-hint{
-      margin-top:var(--space-xs);
-      font-size:0.95rem;
-      color:#475569;
-      display:none;
-    }
-    .selfpay-field .selfpay-hint[data-show="1"]{ display:block; }
-    .plan-qty-toolbar{
-      display:flex;
-      align-items:center;
-      flex-wrap:wrap;
-      gap:8px;
-      margin-top:var(--space-xs);
-    }
-    .plan-qty-hint{
-      font-weight:600;
-      color:rgb(17 17 17 / 0.75);
-      font-size:0.95rem;
-      margin-right:4px;
-    }
-    button.tiny{
-      min-height:calc(var(--h-button-sm) + 4px);
-      padding:var(--button-padding-block-sm) 12px;
-      font-size:17px;
-      border-radius:10px;
-    }
-    .plan-qty-toolbar button[data-variant="ghost"]{
-      background:#f7f9fc;
-      border-color:var(--border);
-      color:#3f3f46;
-    }
-    .plan-qty-toolbar button[data-variant="ghost"]:hover{
-      background:#edf1ff;
-    }
-    .plan-summary-totals{
-      display:grid;
-      grid-template-columns:repeat(1, minmax(0, 1fr));
-      gap:var(--space-sm);
-      margin-bottom:12px;
-    }
-    
-    
-    .plan-summary-total-card{
-      min-width:0;
-      background:#f8fafc;
-      border:1px solid var(--border);
-      border-radius:12px;
-      padding:12px 16px;
-      box-shadow:inset 0 1px 0 rgba(255,255,255,0.6);
-    }
-    .plan-summary-total-label{
-      font-size:0.95rem;
-      color:#475569;
-      margin-bottom:var(--space-xs);
-      font-weight:600;
-    }
-    .plan-summary-total-value{
-      font-size:1.35rem;
-      font-weight:800;
-      color:#0b1d4d;
-    }
-    .plan-summary-total-value.negative{
-      color:#b3261e;
-    }
-    .summary-total-selfpay{
-      margin-top:var(--space-sm);
-      padding-top:var(--space-xs);
-      border-top:1px solid var(--border);
-      text-align:right;
-      font-weight:700;
-      font-size:1rem;
-      color:#0b1d4d;
-    }
-    .plan-summary-totals-hint{
-      font-size:0.95rem;
-      color:#b3261e;
-      margin-bottom:var(--space-sm);
-      display:none;
-    }
-    .plan-summary-totals-hint[data-show="1"]{
-      display:block;
-    }
-    .plan-guideline{
-      margin-bottom:var(--space-md);
-      padding:var(--space-sm) var(--space-md);
-      border-radius:12px;
-      border:1px solid var(--border);
-      background:#f7f9fc;
-      color:#475569;
-      font-size:0.95rem;
-      line-height:1.6;
-    }
-    .plan-guideline p{ margin:0 0 var(--space-xs); }
-    .plan-guideline p:last-child{ margin-bottom:0; }
-    .plan-meta-grid{
-      display:grid;
-      gap:var(--space-sm);
-      grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
-    }
-    .plan-meta-grid > div{
-      display:flex;
-      flex-direction:column;
-      gap:8px;
-    }
-    .plan-meta-grid textarea{ min-height:96px; }
-    .plan-preview{
-      width:100%;
-      min-height:220px;
-      padding:16px;
-      border:1px solid var(--border);
-      border-radius:12px;
-      background:#f7f9fc;
-      font-size:.95rem;
-      line-height:1.6;
-      box-sizing:border-box;
-      white-space:pre-wrap;
-    }
-
-    .auto-hint{
-      display:flex;
-      align-items:center;
-      gap:8px;
-      flex-wrap:wrap;
-    }
-    .auto-hint button.small{
-      height:auto;
-      padding:6px 12px;
-      font-size:.95rem;
-    }
-
-    /* Home care 卡式清單（維持放大字與輸入） */
-    .home-care-grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(260px,1fr)); gap:var(--space-sm); }
-    .home-care-item{
-      position:relative;
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-sm);
-      padding:16px;
-      border:1px solid var(--border);
-      border-radius:14px;
-      background:#fff;
-      box-shadow:var(--shadow);
-      cursor:pointer;
-      transition:border-color .18s ease, box-shadow .18s ease, transform .18s ease;
-      outline:none;
-    }
-    .home-care-item::after{
-      content:"";
-      position:absolute;
-      inset:-2px;
-      border-radius:16px;
-      border:2px solid transparent;
-      pointer-events:none;
-      transition:border-color .18s ease;
-    }
-    .home-care-item:hover{
-      transform:translateY(-2px);
-      box-shadow:0 8px 18px rgba(15,23,42,.12);
-    }
-    .home-care-item:focus-visible::after{
-      border-color:var(--accent);
-    }
-    .home-care-item[data-selected="1"]{
-      border-color:rgba(11,87,208,.45);
-      box-shadow:0 10px 22px rgba(15,23,42,.14);
-    }
-    .home-care-item[data-selected="1"]::after{
-      border-color:rgba(11,87,208,.45);
-    }
-    .home-care-main{
-      display:flex;
-      align-items:center;
-      justify-content:space-between;
-      gap:var(--space-sm);
-    }
-    .home-care-title{
-      display:flex;
-      flex-direction:column;
-      gap:2px;
-      flex:1;
-      min-width:0;
-    }
-    .home-care-code{
-      font-weight:800;
-      color:#0b1d4d;
-      font-size:1.05rem;
-      letter-spacing:.5px;
-    }
-    .home-care-name{
-      color:#111;
-      font-weight:600;
-      font-size:0.98rem;
-      line-height:1.4;
-    }
-    .home-care-status{
-      font-size:0.9rem;
-      font-weight:600;
-      color:#475569;
-    }
-    .home-care-extra{
-      overflow:hidden;
-      max-height:0;
-      opacity:0;
-      transition:max-height .2s ease, opacity .2s ease;
-    }
-    .home-care-item[data-selected="1"] .home-care-extra{
-      max-height:140px;
-      opacity:1;
-    }
-    .home-care-qty-wrap{
-      display:flex;
-      align-items:center;
-      gap:var(--space-xs);
-    }
-    .home-care-qty-label{
-      font-weight:600;
-      color:#1f2937;
-      white-space:nowrap;
-    }
-    .home-care-qty{
-      width:120px;
-      min-height:var(--h-input);
-      padding:var(--ctrl-padding-block) var(--space-sm);
-      font-size:var(--fs-ctrl);
-      border:1px solid var(--border);
-      border-radius:10px;
-      box-sizing:border-box;
-    }
-    .home-care-item[data-has-qty="1"] .home-care-main{
-      align-items:flex-start;
-    }
-
-    /* 預覽框：顏色加深以凸顯區塊 */
-    .preview{
-      padding:var(--space-sm) var(--space-md);
-      background:#eef4ff;
-      border:1px solid #cdd9ff; border-radius:12px;
-      white-space:pre-wrap; font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-      color:#0f172a; max-height:55vh; overflow:auto; font-size:calc(var(--fs-base) * 0.95);
-    }
-    #goalPreview.goal-preview-empty{ color:#6b7280; }
-    .preview-toolbar{
-      display:flex;
-      align-items:center;
-      justify-content:space-between;
-      gap:8px;
-      flex-wrap:wrap;
-    }
-    .preview-card-container{
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-sm);
-      margin-top:var(--space-xs);
-    }
-    .preview-card-container[data-empty="1"]{
-      border:1px dashed var(--border);
-      border-radius:12px;
-      padding:16px;
-      background:#f8fafc;
-    }
-    .preview-empty{ color:#6b7280; font-size:.95rem; }
-    .preview-card{
-      border:1px solid var(--border);
-      border-radius:12px;
-      background:#fff;
-      padding:var(--space-sm) var(--space-md);
-      box-shadow:var(--shadow);
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-xs);
-    }
-    .preview-card[data-changed="1"]{
-      border-color:#f97316;
-      box-shadow:0 0 0 1px rgba(249,115,22,.2), var(--shadow);
-    }
-    .preview-card[data-empty="1"] .preview-card-body{ color:#6b7280; }
-    .preview-card-header{
-      display:flex;
-      align-items:center;
-      justify-content:space-between;
-      gap:var(--space-sm);
-    }
-    .preview-card-title{
-      font-weight:700;
-      color:var(--accent);
-      font-size:1.05rem;
-    }
-    .preview-card-actions{
-      display:flex;
-      gap:8px;
-      flex-wrap:wrap;
-    }
-    .preview-card-body{
-      line-height:1.7;
-      color:#111827;
-      font-size:1rem;
-    }
-    .preview-card-body .diff-add{
-      background:rgba(34,197,94,.18);
-      border-radius:4px;
-      padding:0 2px;
-    }
-    .preview-card-body .diff-del{
-      text-decoration:line-through;
-      color:#b91c1c;
-      background:rgba(239,68,68,.12);
-      border-radius:4px;
-      padding:0 2px;
-    }
-    .preview-card-body .diff-empty{
-      color:#6b7280;
-    }
-    .preview-card-previous{
-      margin-top:var(--space-xs);
-      padding:var(--space-xs) var(--space-sm);
-      border-radius:10px;
-      background:#f8fafc;
-      color:#4b5563;
-      font-size:.95rem;
-    }
-    .preview-card-previous strong{ color:#1f2937; }
-    .preview-toggle.active{
-      background:var(--accent);
-      color:#fff;
-      border-color:var(--accent);
-    }
-    .rule-invalid{
-      border-color:#f97316 !important;
-      box-shadow:0 0 0 2px rgba(249,115,22,.18) !important;
-    }
-
-    /* 提示／狀態色與區隔線 */
-    .hint{ font-size:.95rem; color:#4b5563; }
-    .badge{
-      display:inline-flex;
-      align-items:center;
-      padding:6px 12px;
-      border-radius:999px;
-      background:rgba(11,87,208,.08);
-      color:var(--accent);
-      font-weight:600;
-      min-height:38px;
-    }
-    .danger{ color:#b00020; }
-    .error-messages{ 
-      display:none;
-      margin:10px 0;
-      padding:12px 14px;
-      border:1px solid #fca5a5;
-      border-radius:var(--radius);
-      background:#fef2f2;
-      color:#b91c1c;
-      font-size:.95rem;
-    }
-    .error-messages ul{ margin:0; padding-left:20px; }
-    .error-messages li{ margin-bottom:4px; }
-    .error-summary{
-      display:none;
-      margin:var(--space-xs) 0;
-      padding:12px 14px;
-      border-radius:var(--radius);
-      border:1px solid #fbbf24;
-      background:#fef3c7;
-      color:#92400e;
-      font-size:.95rem;
-      line-height:1.5;
-    }
-    .error-summary a{ color:inherit; text-decoration:underline; }
-    .error-summary a:hover{ text-decoration:none; }
-    .error-summary ul{ margin:0; padding-left:20px; }
-    #section1_block[data-hide-filled="1"] #section1_error_summary[data-show="1"]{ display:block; }
-    #section1_block #section1_error_summary[data-show="0"]{ display:none; }
-    .side-nav{
-      position:fixed;
-      right:max(var(--space-md), env(safe-area-inset-right) + var(--space-md));
-      top:calc(var(--app-top-offset) + var(--space-md));
-      width:var(--side-nav-w);
-      background:var(--card);
-      border:1px solid var(--border);
-      border-radius:14px;
-      box-shadow:var(--shadow);
-      padding:var(--space-sm);
-      display:flex;
-      flex-direction:column;
-      gap:var(--space-xs);
-      z-index:38;
-      color:rgb(17 17 17 / 0.9);
-      max-height:calc(100vh - var(--app-top-offset) - 2 * var(--space-md));
-      overflow:auto;
-      overscroll-behavior:contain;
-    }
-    .side-nav[data-empty="1"]{ display:none; }
-    .side-nav-title{ font-weight:700; color:rgb(17 17 17 / 0.9); font-size:1rem; }
-    .side-nav-list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:var(--space-xs); }
-    .side-nav-item{
-      display:flex;
-      align-items:center;
-      gap:var(--space-xs);
-      padding:var(--space-xs) var(--space-sm);
-      border-radius:999px;
-      border:1px solid var(--border);
-      background:#fff;
-      transition:background .2s ease, border-color .2s ease, box-shadow .2s ease;
-    }
-    .side-nav-item[data-level="3"]{ padding-left:calc(var(--space-sm) + 12px); }
-    .side-nav-item[data-level="4"]{ padding-left:calc(var(--space-sm) + 20px); }
-    .side-nav-item[data-level="5"]{ padding-left:calc(var(--space-sm) + 28px); }
-    .side-nav-item[data-level="6"]{ padding-left:calc(var(--space-sm) + 36px); }
-    .side-nav-item:focus-within{ box-shadow:0 0 0 2px var(--accent-weak); }
-    .side-nav-link{
-      flex:1;
-      min-width:0;
-      text-align:left;
-      background:none;
-      border:none;
-      padding:0;
-      color:rgb(17 17 17 / 0.65);
-      font-size:0.95rem;
-      cursor:pointer;
-      transition:color .2s ease;
-      white-space:nowrap;
-      overflow:hidden;
-      text-overflow:ellipsis;
-    }
-    .side-nav-link:hover,
-    .side-nav-link:focus{ color:var(--accent); outline:none; }
-    .side-nav-count{
-      margin-left:auto;
-      font-size:0.85rem;
-      font-weight:600;
-      color:rgb(17 17 17 / 0.75);
-      font-variant-numeric:tabular-nums;
-      text-align:right;
-    }
-    .side-nav-item[data-status="complete"]{
-      background:rgb(var(--status-complete) / 0.14);
-      border-color:rgb(var(--status-complete) / 0.45);
-    }
-    .side-nav-item[data-status="complete"] .side-nav-link,
-    .side-nav-item[data-status="complete"] .side-nav-count{ color:rgb(var(--status-complete) / 1); }
-    .side-nav-item[data-status="partial"]{
-      background:rgb(var(--status-partial) / 0.18);
-      border-color:rgb(var(--status-partial) / 0.45);
-    }
-    .side-nav-item[data-status="partial"] .side-nav-link,
-    .side-nav-item[data-status="partial"] .side-nav-count{ color:rgb(var(--status-partial) / 1); }
-    .side-nav-item[data-status="pending"]{
-      background:rgb(var(--status-pending) / 0.18);
-      border-color:rgb(var(--status-pending) / 0.45);
-    }
-    .side-nav-item[data-status="pending"] .side-nav-link,
-    .side-nav-item[data-status="pending"] .side-nav-count{ color:rgb(var(--status-pending) / 1); }
-    .side-nav-item[data-status="optional"]{
-      background:rgb(var(--status-optional) / 0.12);
-      border-color:rgb(var(--status-optional) / 0.35);
-    }
-    .side-nav-item[data-status="optional"] .side-nav-link,
-    .side-nav-item[data-status="optional"] .side-nav-count{ color:rgb(var(--status-optional) / 1); }
-    body[data-side-nav-open="1"]{ overflow:hidden; }
-    .side-nav-backdrop{
-      position:fixed;
-      inset:0;
-      background:rgba(15,23,42,.35);
-      backdrop-filter:blur(2px);
-      -webkit-backdrop-filter:blur(2px);
-      opacity:0;
-      pointer-events:none;
-      transition:opacity .3s ease;
-      z-index:37;
-    }
-    body[data-side-nav-open="1"] .side-nav-backdrop{
-      opacity:1;
-      pointer-events:auto;
-    }
-    .side-nav-trigger{
-      display:none;
-      align-items:center;
-      justify-content:center;
-      gap:10px;
-      padding:10px 16px;
-      border:none;
-      border-radius:999px;
-      background:var(--accent);
-      color:#fff;
-      font-weight:600;
-      cursor:pointer;
-      box-shadow:0 8px 18px rgba(15,23,42,.18);
-      transition:background .2s ease, box-shadow .2s ease, transform .2s ease;
-    }
-    .side-nav-trigger:hover,
-    .side-nav-trigger:focus-visible{
-      background:#0a4cbb;
-      outline:none;
-      box-shadow:0 10px 24px rgba(15,23,42,.22);
-    }
-    .side-nav-trigger:focus-visible{ outline:2px solid rgba(255,255,255,.75); outline-offset:2px; }
-    .side-nav-trigger.is-active{ background:#0a4cbb; }
-    .side-nav-trigger[disabled]{ background:#c7d2fe; color:#334155; cursor:not-allowed; box-shadow:none; }
-    .side-nav-trigger[disabled]:hover,
-    .side-nav-trigger[disabled]:focus-visible{
-      background:#c7d2fe;
-      box-shadow:none;
-    }
-    .side-nav-trigger-icon{
-      position:relative;
-      width:20px;
-      height:2px;
-      background:currentColor;
-      border-radius:999px;
-    }
-    .side-nav-trigger-icon::before,
-    .side-nav-trigger-icon::after{
-      content:"";
-      position:absolute;
-      left:0;
-      width:20px;
-      height:2px;
-      background:currentColor;
-      border-radius:999px;
-      transition:transform .2s ease, top .2s ease, background .2s ease;
-    }
-    .side-nav-trigger-icon::before{ top:-6px; }
-    .side-nav-trigger-icon::after{ top:6px; }
-    .side-nav-trigger.is-active .side-nav-trigger-icon{ background:transparent; }
-    .side-nav-trigger.is-active .side-nav-trigger-icon::before{ top:0; transform:rotate(45deg); }
-    .side-nav-trigger.is-active .side-nav-trigger-icon::after{ top:0; transform:rotate(-45deg); }
+      body[data-side-nav-open="1"] .side-nav-trigger{
+        background:var(--color-theme);
+        color:#ffffff;
+        border-color:var(--color-theme);
+      }
+      .side-nav-trigger-icon{
+        position:relative;
+        width:16px;
+        height:16px;
+        border:2px solid currentColor;
+        border-radius:50%;
+      }
+      .side-nav-trigger-icon::before,
+      .side-nav-trigger-icon::after{
+        content:"";
+        position:absolute;
+        left:50%;
+        width:8px;
+        height:2px;
+        background:currentColor;
+        transform:translateX(-50%);
+      }
+      .side-nav-trigger-icon::before{ top:5px; }
+      .side-nav-trigger-icon::after{ top:9px; }
     
     
     
@@ -2217,7 +419,7 @@
       min-width:44px;
       height:44px;
       border-radius:999px;
-      border:1px solid var(--border);
+      border:1px solid #d7dce4;
       background:#fff;
       padding:0;
       font-size:1.5rem;
@@ -2235,7 +437,7 @@
       bottom:calc(100% + 6px);
       right:0;
       min-width:180px;
-      border:1px solid var(--border);
+      border:1px solid #d7dce4;
       border-radius:12px;
       background:#fff;
       box-shadow:0 16px 32px rgba(15,23,42,.16);
@@ -2257,7 +459,7 @@
       margin-top:var(--space-sm);
       padding:16px;
       border:1px solid #fca5a5;
-      border-radius:var(--radius);
+      border-radius:10px;
       background:#fff5f5;
       color:#b3261e;
       font-size:.95rem;
@@ -2375,11 +577,11 @@
       box-shadow:0 0 0 2px rgba(217,45,32,.2) !important;
     }
     .input-complete{
-      border-color:rgb(var(--status-complete) / 0.45) !important;
-      box-shadow:0 0 0 2px rgb(var(--status-complete) / 0.25) !important;
+      border-color:rgba(4,120,87,0.45) !important;
+      box-shadow:0 0 0 2px rgba(4,120,87,0.25) !important;
     }
     .basic-info-field[data-state="complete"] label{
-      color:rgb(var(--status-complete) / 1);
+      color:var(--color-state-complete);
     }
     .basic-info-field[data-state="invalid"] label{
       color:rgb(17 17 17 / 0.75);
@@ -2396,7 +598,7 @@
     .basic-info-status::before{ content:''; font-weight:700; }
     .basic-info-status[data-state="invalid"]{ color:#b91c1c; }
     .basic-info-status[data-state="invalid"]::before{ content:'!'; }
-    .basic-info-status[data-state="complete"]{ color:rgb(var(--status-complete) / 1); }
+    .basic-info-status[data-state="complete"]{ color:var(--color-state-complete); }
     .basic-info-status[data-state="complete"]::before{ content:'✓'; }
     .cms-level-row #cmsLevelGroup{
       transition:box-shadow .2s ease;
@@ -2406,10 +608,10 @@
       border-radius:16px;
     }
     .cms-level-row[data-status="complete"] #cmsLevelGroup{
-      box-shadow:0 0 0 2px rgb(var(--status-complete) / 0.25);
+      box-shadow:0 0 0 2px rgba(4,120,87,0.25);
       border-radius:16px;
     }
-    .cms-level-row[data-status="complete"] > .h3{ color:rgb(var(--status-complete) / 1); }
+    .cms-level-row[data-status="complete"] > .h3{ color:var(--color-state-complete); }
     .cms-level-row[data-status="invalid"] > .h3{ color:rgb(17 17 17 / 0.75); }
     .group[data-plan-locked="1"] .group-header{ opacity:.85; }
     .group[data-plan-locked="1"] .group-collapse{
@@ -2426,7 +628,7 @@
     .group-collapse.is-locked .group-collapse-icon{ opacity:.6; }
     .checkcol.input-invalid{
       border:1px solid #fca5a5;
-      border-radius:var(--radius);
+      border-radius:10px;
       padding:12px 14px;
       background:#fef2f2;
     }
@@ -2512,7 +714,7 @@
       align-items:center;
       gap:8px;
       padding:10px 12px;
-      border:1px solid var(--border, #e5e7eb);
+      border:1px solid #d7dce4;
       border-radius:10px;
       background:#fff;
     }
@@ -2524,6 +726,44 @@
     }
 
     
+    .sticky-summary{
+      display:flex;
+      align-items:center;
+      gap:var(--space-2);
+      flex-wrap:wrap;
+      font-size:0.95rem;
+    }
+    .summary-case{
+      font-weight:700;
+      font-size:1.05rem;
+      color:#111111;
+    }
+    .summary-meta{
+      font-weight:600;
+      color:#475569;
+    }
+    .summary-separator{
+      color:#94a3b8;
+      font-weight:600;
+    }
+    .summary-progress-bar{
+      position:relative;
+      width:120px;
+      height:8px;
+      border-radius:999px;
+      background:#e2e8f0;
+      overflow:hidden;
+      display:inline-block;
+    }
+    .summary-progress-fill{
+      position:absolute;
+      inset:0;
+      width:0%;
+      border-radius:999px;
+      background:var(--color-theme);
+      transition:width .3s ease;
+    }
+
 </style>
 </head>
 
@@ -2570,22 +810,14 @@
                 </div>
               </div>
               <div class="sticky-summary" id="stickySummary" aria-live="polite">
-                <div class="summary-item">
-                  <span class="summary-label">個案</span>
-                  <span class="summary-value" id="summaryCaseName">—</span>
-                </div>
-                <div class="summary-item">
-                  <span class="summary-label">CMS 等級</span>
-                  <span class="summary-value" id="summaryCmsLevel">—</span>
-                </div>
-                <div class="summary-item summary-progress">
-                  <span class="summary-label">完成度</span>
-                  <div class="summary-progress-bar" role="presentation">
-                    <div class="summary-progress-fill" id="summaryProgressFill"></div>
-                  </div>
-                  <span class="summary-progress-text" id="summaryProgressText">—</span>
-                  <span class="summary-remaining-text" id="summaryRemainingText">—</span>
-                </div>
+                <span class="summary-case" id="summaryCaseName">—</span>
+                <span class="summary-separator" aria-hidden="true">·</span>
+                <span class="summary-meta" id="summaryCmsLevel">CMS 等級 —</span>
+                <span class="summary-separator" aria-hidden="true">·</span>
+                <span class="summary-meta" id="summaryProgressText">完成度 —</span>
+                <span class="summary-progress-bar" role="presentation">
+                  <span class="summary-progress-fill" id="summaryProgressFill"></span>
+                </span>
               </div>
             </div>
           </div>
@@ -4105,6 +2337,7 @@
 
   <script>
     /* ===== 版面配置工具 ===== */
+    const DEBUG = typeof window !== 'undefined' && !!(window.AA01_DEBUG || window.DEBUG);
     const FONT_SCALE_STORAGE_KEY = 'AA01.fontScale';
     const FONT_SCALE_DEFAULT = 'sm';
     const FONT_SCALE_OPTIONS = ['sm','xl'];
@@ -4120,8 +2353,7 @@
       caseName:'summaryCaseName',
       cmsLevel:'summaryCmsLevel',
       progressFill:'summaryProgressFill',
-      progressText:'summaryProgressText',
-      remainingText:'summaryRemainingText'
+      progressText:'summaryProgressText'
     };
     const PAGE_LABELS = {
       basic:'基本資訊',
@@ -4748,13 +2980,22 @@
       return map;
     }
 
-    function cardizePageSections(){
-      const sections = Array.from(document.querySelectorAll('[data-section]'));
+    function cardizePageSections(root){
+      const scope = root || document;
+      const sections = Array.from(scope.querySelectorAll('[data-section]'));
       sections.forEach(section=>{
-        normalizeLayout(section);
+        transformSectionLayout(section);
         cleanupEmptyContainers(section);
       });
-      ensureAllGroupBodies(document);
+      ensureAllGroupBodies(scope);
+      return sections;
+    }
+
+    function runCardBuilder(root){
+      const scope = root || document;
+      applyGridUtilities(scope);
+      const sections = cardizePageSections(scope);
+      enforceSection1CardLayout();
       return sections;
     }
 
@@ -4780,9 +3021,7 @@
     function buildInitialDomStructure(){
       ensurePageSectionSkeleton();
       applyHeadingsToDOM(HEADING_SCHEMA);
-      applyGridUtilities(document);
-      const sections = cardizePageSections();
-      enforceSection1CardLayout();
+      const sections = runCardBuilder(document);
       resetHeadingGroupRegistry();
       prepareSectionContainers(sections);
       enhanceInitialCheckcols();
@@ -4806,7 +3045,7 @@
       return card;
     }
 
-    function normalizeLayout(node, options){
+    function transformSectionLayout(node, options){
       if(!node) return null;
 
       function isCardLike(target){
@@ -5066,7 +3305,7 @@
 
     function upgradeLegacyContainers(section){
       if(!section) return;
-      normalizeLayout(section);
+      transformSectionLayout(section);
       applyGridUtilities(section);
     }
 
@@ -5191,7 +3430,7 @@
         audit.s1_cardized = hasCard;
       }
       cleanupEmptyContainers(section);
-      normalizeLayout(section);
+      transformSectionLayout(section);
       scheduleAllMeasurements();
     }
 
@@ -5739,23 +3978,8 @@
       let needsSummary = false;
       let needsSummaryProgress = false;
       let needsSideNav = false;
-      let measureJobScheduled = false;
-      let renderJobScheduled = false;
-
-      function ensureMeasureJob(){
-        if(measureJobScheduled) return;
-        measureJobScheduled = true;
-        Scheduler.enqueue('measure','ui:measure', runMeasure, 'high');
-      }
-
-      function ensureRenderJob(){
-        if(renderJobScheduled) return;
-        renderJobScheduled = true;
-        Scheduler.enqueue('render','ui:render', runRender, 'high');
-      }
 
       function runMeasure(){
-        measureJobScheduled = false;
         if(!needsLayout) return;
         updateVerticalDensityMode();
         measureStickyLayout();
@@ -5763,7 +3987,6 @@
       }
 
       function runRender(){
-        renderJobScheduled = false;
         if(needsLayout){
           renderStickyLayout();
           renderFloatingActionsMetrics();
@@ -5782,23 +4005,23 @@
 
       function requestLayout(){
         needsLayout = true;
-        ensureMeasureJob();
-        ensureRenderJob();
+        Scheduler.enqueue('measure','ui:layout', runMeasure, 'high');
+        Scheduler.enqueue('render','ui:render', runRender, 'high');
       }
 
       function requestSummary(){
         needsSummary = true;
-        ensureRenderJob();
+        Scheduler.enqueue('render','ui:render', runRender, 'high');
       }
 
       function requestSummaryProgress(){
         needsSummaryProgress = true;
-        ensureRenderJob();
+        Scheduler.enqueue('render','ui:render', runRender, 'high');
       }
 
       function requestSideNav(){
         needsSideNav = true;
-        ensureRenderJob();
+        Scheduler.enqueue('render','ui:render', runRender, 'high');
       }
 
       return {
@@ -6248,8 +4471,7 @@
         caseName:document.getElementById(SUMMARY_ELEMENT_IDS.caseName),
         cmsLevel:document.getElementById(SUMMARY_ELEMENT_IDS.cmsLevel),
         progressFill:document.getElementById(SUMMARY_ELEMENT_IDS.progressFill),
-        progressText:document.getElementById(SUMMARY_ELEMENT_IDS.progressText),
-        remainingText:document.getElementById(SUMMARY_ELEMENT_IDS.remainingText)
+        progressText:document.getElementById(SUMMARY_ELEMENT_IDS.progressText)
       };
       return summaryElements;
     }
@@ -6280,27 +4502,19 @@
       const caseNameValue = nameInput ? (nameInput.value || '').trim() : '';
       if(els.caseName) els.caseName.textContent = caseNameValue || '—';
       const cmsLevel = typeof getCmsLevel === 'function' ? (getCmsLevel() || '') : '';
-      if(els.cmsLevel) els.cmsLevel.textContent = cmsLevel || '—';
+      if(els.cmsLevel){
+        els.cmsLevel.textContent = cmsLevel ? `CMS 等級 ${cmsLevel}` : 'CMS 等級 —';
+      }
       const progress = getGlobalProgressState();
       const hasRequired = !!(progress.required);
-      const remainingCount = hasRequired ? Math.max(0, (progress.required || 0) - (progress.filled || 0)) : 0;
       if(els.progressFill) els.progressFill.style.width = `${progress.percent || 0}%`;
       if(els.progressText){
         if(hasRequired){
-          els.progressText.textContent = `已完成 ${progress.filled} / ${progress.required}（${progress.percent}%）`;
+          els.progressText.textContent = `完成度 ${progress.percent}%（${progress.filled}/${progress.required}）`;
         }else if(sectionViewsReady){
-          els.progressText.textContent = '無必填欄位';
+          els.progressText.textContent = '完成度 無必填欄位';
         }else{
-          els.progressText.textContent = '—';
-        }
-      }
-      if(els.remainingText){
-        if(hasRequired){
-          els.remainingText.textContent = remainingCount > 0 ? `剩餘 ${remainingCount} 項` : '全部完成';
-        }else if(sectionViewsReady){
-          els.remainingText.textContent = '無必填欄位';
-        }else{
-          els.remainingText.textContent = '—';
+          els.progressText.textContent = '完成度 —';
         }
       }
     }
@@ -17021,6 +15235,29 @@
     }
 
     window.addEventListener('load', initializeSidebarOnLoad);
+
+    // deprecated
+    function dedupeElementsById(){
+      if(!DEBUG) return;
+    }
+
+    // deprecated
+    function dedupePageSection(){
+      if(!DEBUG) return;
+    }
+
+    // deprecated
+    function hoistNestedPageSections(){
+      if(!DEBUG) return;
+    }
+
+
+    // deprecated
+    function normalizeLayout(node, options){
+      if(!DEBUG) return node;
+      return transformSectionLayout(node, options);
+    }
+
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
* Consolidated design tokens, simplified the sticky summary into a single inline row, and cleaned up side navigation styles for mobile and desktop overlays.【F:Sidebar.html†L23-L183】【F:Sidebar.html†L729-L765】【F:Sidebar.html†L812-L819】
* Reordered the DOM initialization flow to run the new card builder between heading application and field container preparation, introducing `runCardBuilder` for the layout pass.【F:Sidebar.html†L2983-L3029】
* Updated frame coordination to enqueue measure/render work directly through the scheduler and gated legacy layout helpers behind a debug-only shim.【F:Sidebar.html†L3976-L4024】【F:Sidebar.html†L7778-L7837】

## Testing
* ❌ Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d51b64af80832badc813024718cf5d