### PR TITLE
fix: correct selector spreads and rgba alpha values

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -45,7 +45,7 @@
       --fs-ctrl:18px;
 
       --radius:10px;
-      --shadow:0 10px 30px rgba(15,23,42,.08);
+      --shadow:0 10px 30px rgba(15,23,42,0.08);
       --ctrl-padding-block:var(--space-xs);
       --ctrl-padding-inline:var(--space-sm);
       --button-padding-inline:var(--space-md);
@@ -465,7 +465,7 @@
     .group[data-collapsed="1"] .group-content{ display:none; }
     .group-collapse{
       border:none;
-      background:rgba(11,87,208,.08);
+      background:rgba(11,87,208,0.08);
       color:var(--accent);
       font-weight:600;
       font-size:0.9rem;
@@ -479,7 +479,7 @@
     }
     .group-collapse:hover,
     .group-collapse:focus-visible{
-      background:rgba(11,87,208,.16);
+      background:rgba(11,87,208,0.16);
       outline:none;
     }
     .group-collapse-icon{ display:inline-block; transition:transform .2s ease; }
@@ -1371,7 +1371,7 @@
     .checkcol input[type=checkbox]{ width:var(--checkbox); height:var(--checkbox); }
     .checkcol label[data-auto="1"]{
       border-color:rgba(11,87,208,.4);
-      background:rgba(11,87,208,.08);
+      background:rgba(11,87,208,0.08);
     }
 
     /* 需要固定欄寬的首欄位（關係/姓名等） */
@@ -1436,7 +1436,7 @@
     .virtual-checklist-viewport{ position:relative; max-height:320px; overflow-y:auto; }
     .virtual-checklist-visible{ position:absolute; top:0; left:0; right:0; display:flex; flex-direction:column; }
     .virtual-checklist-spacer{ height:0; width:1px; }
-    .virtual-checklist-item{ display:flex; align-items:center; gap:var(--space-xs); padding:var(--space-xs) var(--space-sm); border-bottom:1px solid rgba(15,23,42,.08); background:#fff; }
+    .virtual-checklist-item{ display:flex; align-items:center; gap:var(--space-xs); padding:var(--space-xs) var(--space-sm); border-bottom:1px solid rgba(15,23,42,0.08); background:#fff; }
     .virtual-checklist-item:last-child{ border-bottom:none; }
     .virtual-checklist-item input[type="checkbox"]{ width:var(--checkbox); height:var(--checkbox); }
     .virtual-checklist-print{ display:none; margin-top:var(--space-xs); font-size:0.9rem; line-height:1.45; color:#0f172a; }
@@ -2017,7 +2017,7 @@
       align-items:center;
       padding:6px 12px;
       border-radius:999px;
-      background:rgba(11,87,208,.08);
+      background:rgba(11,87,208,0.08);
       color:var(--accent);
       font-weight:600;
       min-height:38px;
@@ -2225,7 +2225,7 @@
       padding-bottom:max(var(--space-xs), calc(env(safe-area-inset-bottom) + var(--space-xs)));
       background:rgba(255,255,255,.95);
       border-top:1px solid rgba(148,163,184,.35);
-      box-shadow:0 -6px 18px rgba(15,23,42,.08);
+      box-shadow:0 -6px 18px rgba(15,23,42,0.08);
       backdrop-filter:saturate(160%) blur(12px);
       -webkit-backdrop-filter:saturate(160%) blur(12px);
       z-index:80;
@@ -2267,7 +2267,7 @@
       border:1px solid var(--border);
       border-radius:12px;
       background:#fff;
-      box-shadow:0 16px 32px rgba(15,23,42,.16);
+      box-shadow:0 16px 32px rgba(15,23,42,0.16);
       padding:var(--space-xs);
       display:none;
       flex-direction:column;
@@ -2443,13 +2443,13 @@
     .group[data-plan-locked="1"] .group-header{ opacity:.85; }
     .group[data-plan-locked="1"] .group-collapse{
       cursor:not-allowed;
-      background:rgba(148,163,184,.16);
+      background:rgba(148,163,184,0.16);
       color:#64748b;
       border-color:rgba(148,163,184,.4);
     }
     .group[data-plan-locked="1"] .group-collapse:hover,
     .group[data-plan-locked="1"] .group-collapse:focus-visible{
-      background:rgba(148,163,184,.16);
+      background:rgba(148,163,184,0.16);
       color:#64748b;
     }
     .group-collapse.is-locked .group-collapse-icon{ opacity:.6; }
@@ -8161,7 +8161,7 @@
         const nameInput=document.getElementById(`ex-name-${currentIndex}`);
         let appliedCustom = false;
         if(select){
-          const hasOption = rawRole && [...select.options].some(opt=>opt.value===rawRole);
+          const hasOption = rawRole && Array.from(select.options).some(opt=>opt.value===rawRole);
           if(hasOption){
             select.value = rawRole;
           }else if(rawRole){
@@ -14861,7 +14861,7 @@
         const nameInput=document.getElementById(`cc-name-${currentIndex}`);
         let appliedCustom=false;
         if(select){
-          const hasOption = rel && [...select.options].some(opt=>opt.value===rel);
+          const hasOption = rel && Array.from(select.options).some(opt=>opt.value===rel);
           if(hasOption){
             select.value = rel;
           }else if(rel){


### PR DESCRIPTION
## Summary
- normalize rgba alpha values in Sidebar styles to use valid decimal notation
- use Array.from when inspecting select options during extras and co-care restoration

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d567b11f04832bbbf200aa96bb7f4c