### PR TITLE
Add automated GAS deployment workflow

### DIFF
--- a/.clasp.json
+++ b/.clasp.json
@@ -1,4 +1,3 @@
-﻿{
-  "scriptId": "11eWxWJyImruzOO_lTuU-VDqrMZ5OKNE62RguM8RQBntrBPMxfCtisxaP",
-  "rootDir": "."
+{
+  "scriptId": "11eWxWJyImruzOO_lTuU-VDqrMZ5OKNE62RguM8RQBntrBPMxfCtisxaP"
 }

--- a/.github/workflows/gas-deploy.yml
+++ b/.github/workflows/gas-deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy GAS Web App
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install clasp
+        run: npm i -g @google/clasp
+
+      - name: Restore ~/.clasprc.json from secret
+        run: |
+          echo "${{ secrets.CLASPRC_JSON }}" > ~/.clasprc.json
+          chmod 600 ~/.clasprc.json
+
+      # 若你的 GAS 原始碼在子資料夾，這裡可先 cd 再執行
+      - name: Push code to GAS
+        run: npm run gas:push
+
+      - name: Create version & update existing deployment
+        env:
+          GAS_DEPLOY_ID: ${{ vars.GAS_DEPLOY_ID }}
+        run: |
+          npm run gas:deploy

--- a/package.json
+++ b/package.json
@@ -1,13 +1,18 @@
 {
-  "name": "aa01",
+  "name": "gas-webapp",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "devDependencies": {
     "@google/clasp": "^2.5.0"
   },
   "scripts": {
     "test": "echo \"no tests yet\"",
     "deploy:web": "node gas-deploy.mjs",
-    "oauth:token": "node get-refresh-token.mjs"
+    "oauth:token": "node get-refresh-token.mjs",
+    "gas:push": "clasp push --force",
+    "gas:version": "node ./scripts/gas-version.js",
+    "gas:deploy": "node ./scripts/gas-deploy.js",
+    "gas:release": "npm run gas:push && npm run gas:version && npm run gas:deploy"
   }
 }

--- a/scripts/gas-deploy.js
+++ b/scripts/gas-deploy.js
@@ -1,0 +1,12 @@
+import { execSync } from "node:child_process";
+
+const DEPLOY_ID = process.env.GAS_DEPLOY_ID; // 來自 repo variable
+if (!DEPLOY_ID) {
+  console.error("缺少 GAS_DEPLOY_ID 環境變數");
+  process.exit(1);
+}
+
+const ver = execSync("node ./scripts/gas-version.js", { encoding: "utf8" }).trim();
+const desc = `ci deploy ${new Date().toISOString()}`;
+
+execSync(`clasp deploy -i ${DEPLOY_ID} -V ${ver} -d "${desc}"`, { stdio: "inherit" });

--- a/scripts/gas-version.js
+++ b/scripts/gas-version.js
@@ -1,0 +1,11 @@
+import { execSync } from "node:child_process";
+
+const desc = `ci build ${new Date().toISOString()}`;
+const out = execSync(`clasp version "${desc}"`, { encoding: "utf8" });
+const m = out.match(/version (\d+)/);
+if (!m) {
+  console.error("無法解析版本號，clasp 輸出:\n" + out);
+  process.exit(1);
+}
+const ver = m[1];
+console.log(ver); // 印純版本號，後續腳本直接取用


### PR DESCRIPTION
## Summary
- configure clasp to use the existing Apps Script ID without a rootDir override
- add Node scripts for pushing, versioning, and deploying the GAS project
- create a GitHub Actions workflow to push and deploy on merges to main

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d86b7a8be0832ba6621795da59db6e