### PR TITLE
Highlight CI environments in GAS deployments

### DIFF
--- a/.github/workflows/gas-deploy.yml
+++ b/.github/workflows/gas-deploy.yml
@@ -84,6 +84,17 @@ jobs:
         run: node -e "const fs=require('fs'),id=process.env.TEST_DEPLOYMENT_ID;const arr=JSON.parse(fs.readFileSync('before.json','utf8'));if(!id||!arr.includes(id)){console.error('TEST_DEPLOYMENT_ID not found. IDs=',arr);process.exit(1)};console.log('Found test deployment ID BEFORE.')"
 
       # --- push & deploy to TEST ---
+      - name: "Inject CI env (TEST)"
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          set -e
+          SHORT_SHA="${SHA::7}"
+          cat > 00_ci_env.gs <<EOF
+          const CI_ENV = 'TEST';
+          const CI_SHA_SHORT = '${SHORT_SHA}';
+          EOF
+
       - name: "Push to Apps Script (TEST)"
         run: clasp push -f
 
@@ -96,7 +107,7 @@ jobs:
           set -o pipefail
           set +e
           log=$(mktemp)
-          clasp deploy --deploymentId "$TEST_DEPLOYMENT_ID" -d "CI STAGE ${GITHUB_SHA}" 2>&1 | tee "$log"
+          clasp deploy --deploymentId "$TEST_DEPLOYMENT_ID" -d "[TEST] CI ${GITHUB_SHA::7}" 2>&1 | tee "$log"
           status=$?
           set -e
           set +o pipefail
@@ -180,6 +191,17 @@ jobs:
           test -s "$HOME/.clasprc.json"
           cp "$HOME/.clasprc.json" "$GITHUB_WORKSPACE/.clasprc.json"
 
+      - name: "Inject CI env (PROD)"
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          set -e
+          SHORT_SHA="${SHA::7}"
+          cat > 00_ci_env.gs <<EOF
+          const CI_ENV = 'PROD';
+          const CI_SHA_SHORT = '${SHORT_SHA}';
+          EOF
+
       - name: "Push to Apps Script (PROD)"
         run: clasp push -f
 
@@ -192,7 +214,7 @@ jobs:
           set -o pipefail
           set +e
           log=$(mktemp)
-          clasp deploy --deploymentId "$GAS_DEPLOYMENT_ID" -d "CI PROD ${GITHUB_SHA}" 2>&1 | tee "$log"
+          clasp deploy --deploymentId "$GAS_DEPLOYMENT_ID" -d "[PROD] CI ${GITHUB_SHA::7}" 2>&1 | tee "$log"
           status=$?
           set -e
           set +o pipefail

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ AA01 是一套以 Google Apps Script 打造的 Google 文件附加功能。長�
 
 > 更新日期：2025-10-21
 
+## Environments
+
+- **TEST**: `https://script.google.com/macros/s/AKfycbw1-3KBUwTLymBMK6pzNrvvaW9bxfNOGKPSNhsscssDwc9buXAJ3sUTbhljLiHcEDrh/exec?route=health`
+- **PROD**: `https://script.google.com/macros/s/AKfycbyDt6M-PYyU-ANWU2fQrLF4w_9T_f1ADZLFNNInG0_orf4LhmnLHt8peBen8v2mTY-c/exec?route=health`
+
 ## 快速開始（Quickstart）
 
 1. **複製專案檔案**：在目標 Google 文件中開啟 `Extensions → Apps Script`，將本儲存庫的 `.gs` 與 `Sidebar.html` 內容貼入新建專案。

--- a/src/AppCore.gs
+++ b/src/AppCore.gs
@@ -36,8 +36,10 @@ function doGet(e) {
   try {
     var p = (e && e.parameter) || {};
     if (p.route === 'health') {
+      var env = (typeof CI_ENV !== 'undefined') ? CI_ENV : 'UNKNOWN';
+      var sha = (typeof CI_SHA_SHORT !== 'undefined') ? CI_SHA_SHORT : 'local';
       return ContentService
-        .createTextOutput(JSON.stringify({ ok: true, ts: new Date().toISOString() }))
+        .createTextOutput(JSON.stringify({ ok: true, env: env, sha: sha, ts: new Date().toISOString() }))
         .setMimeType(ContentService.MimeType.JSON);
     }
     // 你原本的主畫面輸出


### PR DESCRIPTION
## Summary
- inject CI environment metadata into the staged and production deployment steps so the Apps Script health route can read it
- update the GitHub Actions deployment descriptions to visibly label TEST and PROD runs
- surface the available TEST and PROD health URLs in the README for quick access

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc2552f1a0832ba510b93e944eb640