### PR TITLE
Enforce version verification in GAS workflow

### DIFF
--- a/.github/workflows/gas-deploy.yml
+++ b/.github/workflows/gas-deploy.yml
@@ -75,28 +75,52 @@ jobs:
       - name: "Snapshot BEFORE"
         run: |
           set -e
-          clasp list-deployments > before.txt || clasp deployments > before.txt || true
-          node -e "const fs=require('fs');const t=fs.readFileSync('before.txt','utf8');const ids=[...t.matchAll(/AK[a-zA-Z0-9_-]{20,}/g)].map(m=>m[0]);fs.writeFileSync('before.json',JSON.stringify([...new Set(ids)]));console.log('BEFORE IDs:',ids.join(',')||'(none)')"
+          clasp deployments > before.txt || true
+          node -e "const fs=require('fs');const t=fs.readFileSync('before.txt','utf8');const lines=t.split(/\r?\n/);const map={};for(const L of lines){const m=L.match(/(AK[\w-]{20,}).*@([0-9]+)/);if(m){map[m[1]]=m[2];}}fs.writeFileSync('before.map.json',JSON.stringify(map));console.log('BEFORE MAP:',map)"
 
       - name: "Ensure TEST_DEPLOYMENT_ID exists BEFORE"
         env:
           TEST_DEPLOYMENT_ID: ${{ secrets.TEST_DEPLOYMENT_ID }}
-        run: node -e "const fs=require('fs'),id=process.env.TEST_DEPLOYMENT_ID;const arr=JSON.parse(fs.readFileSync('before.json','utf8'));if(!id||!arr.includes(id)){console.error('TEST_DEPLOYMENT_ID not found. IDs=',arr);process.exit(1)};console.log('Found test deployment ID BEFORE.')"
+        run: |
+          node -e "const fs=require('fs');const id=process.env.TEST_DEPLOYMENT_ID;const map=JSON.parse(fs.readFileSync('before.map.json','utf8'));if(!id||!map[id]){console.error('TEST_DEPLOYMENT_ID not found.');process.exit(1);}console.log('Found test deployment BEFORE. Current version =',map[id]);"
 
       # --- push & deploy to TEST ---
+      - name: "Inject CI env (TEST)"
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          set -e
+          SHORT_SHA="${SHA::7}"
+          cat > 00_ci_env.gs <<EOF
+          const CI_ENV = 'TEST';
+          const CI_SHA_SHORT = '${SHORT_SHA}';
+          EOF
+
       - name: "Push to Apps Script (TEST)"
         run: clasp push -f
 
-      - name: "Deploy to TEST"
+      - name: "Create new version (TEST)"
+        id: mkver-test
+        run: |
+          set -e
+          out=$(clasp version -d "[TEST] CI ${GITHUB_SHA::7}" || true)
+          echo "$out"
+          ver=$(echo "$out" | sed -n "s/Created version \([0-9][0-9]*\).*/\1/p")
+          if [ -z "$ver" ]; then echo "::error::Failed to parse version"; exit 1; fi
+          echo "NEW_VER=$ver" >> "$GITHUB_ENV"
+          echo "new_ver=$ver" >> "$GITHUB_OUTPUT"
+
+      - name: "Update deployment to NEW_VER (TEST)"
         env:
           TEST_DEPLOYMENT_ID: ${{ secrets.TEST_DEPLOYMENT_ID }}
         run: |
           set -e
           [ -n "${TEST_DEPLOYMENT_ID:-}" ] || { echo "::error::Missing TEST_DEPLOYMENT_ID"; exit 1; }
+          [ -n "${NEW_VER:-}" ] || { echo "::error::Missing NEW_VER"; exit 1; }
           set -o pipefail
           set +e
           log=$(mktemp)
-          clasp deploy --deploymentId "$TEST_DEPLOYMENT_ID" -d "CI STAGE ${GITHUB_SHA}" 2>&1 | tee "$log"
+          clasp deploy --deploymentId "$TEST_DEPLOYMENT_ID" --versionNumber "$NEW_VER" -d "[TEST] CI ${GITHUB_SHA::7}" 2>&1 | tee "$log"
           status=$?
           set -e
           set +o pipefail
@@ -111,14 +135,33 @@ jobs:
           rm -f "$log"
 
       # AFTER snapshot (TEST)
-      - name: "Snapshot AFTER (TEST)"
+      - name: "Verify deployment points to NEW_VER (TEST)"
         env:
           TEST_DEPLOYMENT_ID: ${{ secrets.TEST_DEPLOYMENT_ID }}
         run: |
           set -e
-          clasp list-deployments > after.txt || clasp deployments > after.txt || true
-          node -e "const fs=require('fs');const t=fs.readFileSync('after.txt','utf8');const ids=[...t.matchAll(/AK[a-zA-Z0-9_-]{20,}/g)].map(m=>m[0]);fs.writeFileSync('after.json',JSON.stringify([...new Set(ids)]));console.log('AFTER IDs:',ids.join(',')||'(none)')"
-          node -e "const fs=require('fs'),b=JSON.parse(fs.readFileSync('before.json','utf8')),a=JSON.parse(fs.readFileSync('after.json','utf8'));const id=process.env.TEST_DEPLOYMENT_ID;console.log('before=',b.length,'after=',a.length,'hasTarget=',a.includes(id)); if(!a.includes(id)){process.exit(1)}"
+          if [ "${TEST_DEPLOYMENT_READONLY:-}" = "true" ]; then
+            echo "Skipping verification because deployment is read-only"; exit 0;
+          fi
+          clasp deployments > after.txt || true
+          node -e "
+            const fs=require('fs');
+            const id=process.env.TEST_DEPLOYMENT_ID;
+            const ver=process.env.NEW_VER;
+            const t=fs.readFileSync('after.txt','utf8');
+            const lines=t.split(/\r?\n/);
+            let cur=null;
+            for(const L of lines){
+              const m=L.match(/(AK[\w-]{20,}).*@([0-9]+)/);
+              if(m && m[1]===id){ cur=m[2]; break; }
+            }
+            if(!cur){ console.error('Dep ID not found AFTER'); process.exit(1); }
+            console.log('Deployment', id, 'now points to version', cur);
+            if(String(cur)!==String(ver)){
+              console.error('Version mismatch: expected', ver, 'got', cur);
+              process.exit(1);
+            }
+          "
 
       # --- Unit tests / E2E tests (可先無檔；--if-present 不會 fail) ---
       - name: "Run unit tests (Jest)"
@@ -180,19 +223,54 @@ jobs:
           test -s "$HOME/.clasprc.json"
           cp "$HOME/.clasprc.json" "$GITHUB_WORKSPACE/.clasprc.json"
 
+      - name: "Snapshot BEFORE"
+        run: |
+          set -e
+          clasp deployments > before.txt || true
+          node -e "const fs=require('fs');const t=fs.readFileSync('before.txt','utf8');const lines=t.split(/\r?\n/);const map={};for(const L of lines){const m=L.match(/(AK[\w-]{20,}).*@([0-9]+)/);if(m){map[m[1]]=m[2];}}fs.writeFileSync('before.map.json',JSON.stringify(map));console.log('BEFORE MAP:',map)"
+
+      - name: "Ensure GAS_DEPLOYMENT_ID exists BEFORE"
+        env:
+          GAS_DEPLOYMENT_ID: ${{ secrets.GAS_DEPLOYMENT_ID }}
+        run: |
+          node -e "const fs=require('fs');const id=process.env.GAS_DEPLOYMENT_ID;const map=JSON.parse(fs.readFileSync('before.map.json','utf8'));if(!id||!map[id]){console.error('GAS_DEPLOYMENT_ID not found.');process.exit(1);}console.log('Found prod deployment BEFORE. Current version =',map[id]);"
+
+      - name: "Inject CI env (PROD)"
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          set -e
+          SHORT_SHA="${SHA::7}"
+          cat > 00_ci_env.gs <<EOF
+          const CI_ENV = 'PROD';
+          const CI_SHA_SHORT = '${SHORT_SHA}';
+          EOF
+
       - name: "Push to Apps Script (PROD)"
         run: clasp push -f
 
-      - name: "Deploy to PROD"
+      - name: "Create new version (PROD)"
+        id: mkver-prod
+        run: |
+          set -e
+          out=$(clasp version -d "[PROD] CI ${GITHUB_SHA::7}" || true)
+          echo "$out"
+          ver=$(echo "$out" | sed -n "s/Created version \([0-9][0-9]*\).*/\1/p")
+          if [ -z "$ver" ]; then echo "::error::Failed to parse version"; exit 1; fi
+          echo "NEW_VER=$ver" >> "$GITHUB_ENV"
+          echo "new_ver=$ver" >> "$GITHUB_OUTPUT"
+
+      - name: "Update deployment to NEW_VER (PROD)"
         env:
           GAS_DEPLOYMENT_ID: ${{ secrets.GAS_DEPLOYMENT_ID }}
         run: |
           set -e
           [ -n "${GAS_DEPLOYMENT_ID:-}" ] || { echo "::error::Missing GAS_DEPLOYMENT_ID"; exit 1; }
+          [ -n "${NEW_VER:-}" ] || { echo "::error::Missing NEW_VER"; exit 1; }
           set -o pipefail
           set +e
           log=$(mktemp)
-          clasp deploy --deploymentId "$GAS_DEPLOYMENT_ID" -d "CI PROD ${GITHUB_SHA}" 2>&1 | tee "$log"
+          clasp deploy --deploymentId "$GAS_DEPLOYMENT_ID" --versionNumber "$NEW_VER" -d "[PROD] CI ${GITHUB_SHA::7}" 2>&1 | tee "$log"
           status=$?
           set -e
           set +o pipefail
@@ -206,6 +284,33 @@ jobs:
           fi
           rm -f "$log"
 
+      - name: "Verify deployment points to NEW_VER (PROD)"
+        env:
+          GAS_DEPLOYMENT_ID: ${{ secrets.GAS_DEPLOYMENT_ID }}
+        run: |
+          set -e
+          if [ "${PROD_DEPLOYMENT_READONLY:-}" = "true" ]; then
+            echo "Skipping verification because deployment is read-only"; exit 0;
+          fi
+          clasp deployments > after.txt || true
+          node -e "
+            const fs=require('fs');
+            const id=process.env.GAS_DEPLOYMENT_ID;
+            const ver=process.env.NEW_VER;
+            const t=fs.readFileSync('after.txt','utf8');
+            const lines=t.split(/\r?\n/);
+            let cur=null;
+            for(const L of lines){
+              const m=L.match(/(AK[\w-]{20,}).*@([0-9]+)/);
+              if(m && m[1]===id){ cur=m[2]; break; }
+            }
+            if(!cur){ console.error('Dep ID not found AFTER'); process.exit(1); }
+            console.log('Deployment', id, 'now points to version', cur);
+            if(String(cur)!==String(ver)){
+              console.error('Version mismatch: expected', ver, 'got', cur);
+              process.exit(1);
+            }
+          "
 
       - name: "Health check (PROD)"
         env:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ AA01 是一套以 Google Apps Script 打造的 Google 文件附加功能。長�
 
 > 更新日期：2025-10-21
 
+## Environments
+
+- **TEST**: `https://script.google.com/macros/s/AKfycbw1-3KBUwTLymBMK6pzNrvvaW9bxfNOGKPSNhsscssDwc9buXAJ3sUTbhljLiHcEDrh/exec?route=health`
+- **PROD**: `https://script.google.com/macros/s/AKfycbyDt6M-PYyU-ANWU2fQrLF4w_9T_f1ADZLFNNInG0_orf4LhmnLHt8peBen8v2mTY-c/exec?route=health`
+
 ## 快速開始（Quickstart）
 
 1. **複製專案檔案**：在目標 Google 文件中開啟 `Extensions → Apps Script`，將本儲存庫的 `.gs` 與 `Sidebar.html` 內容貼入新建專案。

--- a/src/AppCore.gs
+++ b/src/AppCore.gs
@@ -36,8 +36,10 @@ function doGet(e) {
   try {
     var p = (e && e.parameter) || {};
     if (p.route === 'health') {
+      var env = (typeof CI_ENV !== 'undefined') ? CI_ENV : 'UNKNOWN';
+      var sha = (typeof CI_SHA_SHORT !== 'undefined') ? CI_SHA_SHORT : 'local';
       return ContentService
-        .createTextOutput(JSON.stringify({ ok: true, ts: new Date().toISOString() }))
+        .createTextOutput(JSON.stringify({ ok: true, env: env, sha: sha, ts: new Date().toISOString() }))
         .setMimeType(ContentService.MimeType.JSON);
     }
     // 你原本的主畫面輸出


### PR DESCRIPTION
## Summary
- inject CI environment metadata into the staged and production deployment steps so the Apps Script health route can read it
- update the GitHub Actions deployment descriptions to visibly label TEST and PROD runs
- surface the available TEST and PROD health URLs in the README for quick access
- ensure the staged and production workflows create new script versions, redeploy the fixed IDs to those versions, and verify the IDs now point at the fresh builds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc2552f1a0832ba510b93e944eb640