### PR TITLE
Fix npm upgrade workflow token handling

### DIFF
--- a/.github/workflows/npm-auto-upgrade.yml
+++ b/.github/workflows/npm-auto-upgrade.yml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ env.PR_TOKEN }}
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -122,6 +124,13 @@ jobs:
             fs.writeFileSync(summaryPath, md);
           }
           NODE
+
+      - name: Validate PR token permissions
+        run: |
+          if [ "${PR_TOKEN}" = "" ]; then
+            echo "::error::PR token is not configured. Set the NPM_UPGRADE_TOKEN secret with a token that has repo scope."
+            exit 1
+          fi
 
       - name: Upload outdated comparison
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- ensure the checkout step uses the same token that will be used for publishing the npm upgrade branch
- add an explicit validation step that fails fast with a helpful message when the PR token is missing

## Testing
- No tests were run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dc43c0c400832baf3aa4074c2c0b2b