### PR TITLE
Update npm auto upgrade workflow permissions

### DIFF
--- a/.github/workflows/npm-auto-upgrade.yml
+++ b/.github/workflows/npm-auto-upgrade.yml
@@ -1,3 +1,7 @@
+permissions:
+  contents: write
+  pull-requests: write
+
 name: npm auto upgrade
 
 on:
@@ -12,10 +16,6 @@ on:
         options:
           - safe
           - major
-
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
   upgrade:
@@ -145,7 +145,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ env.PR_TOKEN }}
+          token: ${{ github.token }}
           commit-message: ${{ steps.metadata.outputs.commit_message }}
           branch: ${{ steps.metadata.outputs.branch }}
           title: ${{ steps.metadata.outputs.title }}


### PR DESCRIPTION
## Summary
- add explicit contents and pull-request permissions at the top of the npm auto upgrade workflow
- configure the create-pull-request step to use the default `github.token`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc487e49b8832b8d6c0e93b4f7321c