### PR TITLE
Update GAS workflow triggers and conditions

### DIFF
--- a/.github/workflows/gas-deploy.yml
+++ b/.github/workflows/gas-deploy.yml
@@ -1,6 +1,8 @@
 name: GAS staged test & deploy (single workflow)
 
 on:
+  pull_request:
+    branches: [ "main" ]
   push:
     branches: [ "main" ]
   workflow_dispatch:
@@ -15,6 +17,7 @@ defaults:
 
 jobs:
   test-stage:
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -148,6 +151,16 @@ jobs:
       - name: "Run unit tests (Jest)"
         run: npm test --if-present
 
+      - name: "Debug TEST_DEPLOYMENT_ID length"
+        env:
+          TEST_DEPLOYMENT_ID: ${{ secrets.TEST_DEPLOYMENT_ID }}
+        run: |
+          if [ -n "${TEST_DEPLOYMENT_ID:-}" ]; then
+            echo "len=${#TEST_DEPLOYMENT_ID}"
+          else
+            echo "len=0 (empty)"
+          fi
+
       - name: "Run E2E tests (Puppeteer) against TEST"
         env:
           TEST_DEPLOYMENT_ID: ${{ secrets.TEST_DEPLOYMENT_ID }}
@@ -171,6 +184,7 @@ jobs:
           echo "::error::TEST health check failed (code=${code} location=${loc})"; exit 1
 
   deploy-prod:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [test-stage]
     timeout-minutes: 20


### PR DESCRIPTION
## Summary
- trigger the GAS workflow for both pull requests against main and direct pushes
- ensure the test-stage job runs for PRs and main pushes while deploy-prod is limited to main with a successful test gate
- add a debug step to surface the TEST_DEPLOYMENT_ID length before executing E2E tests

## Testing
- Not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dc4a28629c832bba55f41e32e34a58