### PR TITLE
Ensure Sidebar resources are not ignored by clasp

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -7,16 +7,9 @@ dist/**
 build/**
 coverage/**
 .vscode/**
-*.map
-README*
-LICENSE*
-*.md
 scripts/**
 test/**
-jest.config.js
-gas-deploy.mjs
-get-refresh-token.mjs
-package.json
-package-lock.json
-pnpm-lock.yaml
-yarn.lock
+
+# 保留核心 Apps Script 原始碼與 HTML 模板，避免被誤忽略
+!src/**/*.gs
+!src/**/*.html


### PR DESCRIPTION
## Summary
- simplify `.claspignore` to only exclude tooling directories
- explicitly keep source `.gs` and `.html` files to guarantee sidebar assets are pushed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc4d3e529c832b8dca487eee3afee2