### PR TITLE
fix: use commonjs jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   roots: ["<rootDir>/__tests__"],
   testEnvironment: "node",
   moduleFileExtensions: ["js", "cjs", "mjs", "ts", "tsx", "json"],


### PR DESCRIPTION
## Summary
- switch the Jest configuration file to CommonJS syntax so clasp push no longer fails on `export`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4e5246e8832b8c29e23234bea859