### PR TITLE
fix: add ci-safe flags to puppeteer launch

### DIFF
--- a/e2e/responsive.e2e.test.js
+++ b/e2e/responsive.e2e.test.js
@@ -22,7 +22,10 @@ const viewports = [
 (async () => {
   await fs.promises.mkdir(screenshotDir, { recursive: true });
 
-  const browser = await puppeteer.launch({ headless: true });
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  });
 
   try {
     for (const viewport of viewports) {


### PR DESCRIPTION
## Summary
- add no-sandbox launch arguments to puppeteer responsive test to improve CI stability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcc3783490832ba204dd3b3e3e27fb