### PR TITLE
fix: replace unsupported wait timeout

### DIFF
--- a/e2e/responsive.e2e.test.js
+++ b/e2e/responsive.e2e.test.js
@@ -38,7 +38,7 @@ const viewports = [
         console.warn(`Navigation warning for ${viewport.label}:`, error.message);
       }
 
-      await page.waitForTimeout(2000);
+      await new Promise(resolve => setTimeout(resolve, 2000));
 
       const fileName = `responsive-${viewport.label}-${viewport.width}x${viewport.height}.png`;
       const filePath = path.join(screenshotDir, fileName);


### PR DESCRIPTION
## Summary
- replace the deprecated `page.waitForTimeout` call in the responsive E2E test with a standard `setTimeout`-based delay

## Testing
- npm run e2e

------
https://chatgpt.com/codex/tasks/task_e_68dcc4b688f0832ba81cc748c0bbbc09