### PR TITLE
feat: refresh sidebar layout and navigation

### DIFF
--- a/src/Sidebar.html
+++ b/src/Sidebar.html
@@ -34,6 +34,14 @@
       --status-pending:31 41 55;
       --status-optional:71 85 105;
 
+      --progress-low:#dc2626;
+      --progress-mid:#f59e0b;
+      --progress-high:#16a34a;
+
+      --banner-info:#2563eb;
+      --banner-warn:#b45309;
+      --banner-error:#dc2626;
+
       --space-xxs:4px;
       --space-xs:8px;
       --space-sm:12px;
@@ -45,7 +53,8 @@
       --fs-ctrl:18px;
 
       --radius:10px;
-      --shadow:0 10px 30px rgba(15,23,42,0.08);
+      --shadow:0 12px 24px rgba(15,23,42,0.08);
+      --shadow-soft:0 10px 24px rgba(15,23,42,0.06);
       --ctrl-padding-block:var(--space-xs);
       --ctrl-padding-inline:var(--space-sm);
       --button-padding-inline:var(--space-md);
@@ -162,9 +171,16 @@
     
       .extras-heading-grid{ grid-template-columns:1fr; }
     
+      .app-body-controls{
+        position:fixed !important;
+        right:max(var(--space-md), calc(env(safe-area-inset-right) + var(--space-md))) !important;
+        bottom:calc(var(--fab-gap) + var(--bottom-bar-min-height) + 20px) !important;
+        padding:0 !important;
+        z-index:95 !important;
+      }
       .side-nav{
-        right:max(var(--space-sm), env(safe-area-inset-right) + var(--space-sm));
-        bottom:max(var(--space-md), env(safe-area-inset-bottom) + var(--space-md));
+        right:max(var(--space-sm), calc(env(safe-area-inset-right) + var(--space-sm)));
+        bottom:max(var(--space-md), calc(env(safe-area-inset-bottom) + var(--space-md)));
         left:auto;
         width:min(92vw, 320px);
         transform:translateX(calc(100% + var(--space-md)));
@@ -178,8 +194,16 @@
         pointer-events:auto;
       }
       .side-nav-trigger{
-        display:inline-flex;
-        margin:var(--space-sm) 0 var(--space-xs);
+        position:relative !important;
+        display:inline-flex !important;
+        align-items:center;
+        gap:var(--space-xxs) !important;
+        padding:14px 18px !important;
+        border-radius:999px !important;
+        background:var(--accent) !important;
+        color:#fff !important;
+        box-shadow:var(--shadow-soft) !important;
+        font-weight:700 !important;
       }
     
       #wizardPrevBtn{ display:none; }
@@ -419,6 +443,78 @@
       gap:var(--space-sm);
       position:relative;
     }
+    .global-banner{
+      display:none;
+      flex-direction:column;
+      align-items:stretch;
+      gap:var(--space-sm);
+      padding:var(--space-xs) var(--space-md);
+      margin-inline:clamp(12px, 4vw, 24px);
+      margin-bottom:var(--space-sm);
+      border-radius:var(--radius);
+      border:1px solid transparent;
+      background:rgba(37,99,235,0.08);
+      box-shadow:var(--shadow-soft);
+      color:var(--banner-info);
+    }
+    .global-banner[data-visible="1"]{ display:flex; }
+    .global-banner[data-type="info"]{
+      background:rgba(37,99,235,0.12);
+      border-color:rgba(37,99,235,0.32);
+      color:var(--banner-info);
+    }
+    .global-banner[data-type="warn"]{
+      background:rgba(180,83,9,0.12);
+      border-color:rgba(180,83,9,0.35);
+      color:var(--banner-warn);
+    }
+    .global-banner[data-type="error"]{
+      background:rgba(220,38,38,0.12);
+      border-color:rgba(220,38,38,0.38);
+      color:var(--banner-error);
+    }
+    .global-banner-content{
+      display:flex;
+      flex-direction:column;
+      gap:var(--space-xxs);
+      flex:1 1 auto;
+      min-width:0;
+    }
+    .global-banner-title{
+      font-weight:700;
+      font-size:1rem;
+    }
+    .global-banner-text{
+      font-size:0.95rem;
+      line-height:1.6;
+      color:inherit;
+    }
+    .global-banner-actions{
+      display:flex;
+      flex-wrap:wrap;
+      gap:var(--space-xxs);
+      justify-content:flex-end;
+      align-self:flex-end;
+    }
+    .global-banner button{
+      border:none;
+      border-radius:999px;
+      padding:8px 14px;
+      font-weight:600;
+      cursor:pointer;
+      background:rgba(255,255,255,0.9);
+      color:inherit;
+      box-shadow:0 4px 10px rgba(15,23,42,0.08);
+    }
+    .global-banner button:hover,
+    .global-banner button:focus-visible{
+      background:#fff;
+      outline:none;
+      box-shadow:0 6px 14px rgba(15,23,42,0.12);
+    }
+    .global-banner-close{
+      min-width:40px;
+    }
     .app-body-controls{
       display:flex;
       justify-content:flex-end;
@@ -581,6 +677,23 @@
       margin-top:var(--space-md);
       margin-bottom:var(--space-xs);
     }
+    #caseOverviewGroup [data-section] > .titlebar{
+      margin-top:var(--space-lg);
+      margin-bottom:var(--space-sm);
+      padding:var(--space-xs) var(--space-sm);
+      border-radius:var(--radius);
+      border-left:4px solid var(--accent);
+      background:rgba(11,87,208,0.08);
+      box-shadow:var(--shadow-soft);
+    }
+    #caseOverviewGroup [data-section]:first-of-type > .titlebar{
+      margin-top:var(--space-md);
+    }
+    #caseOverviewGroup [data-section] > .titlebar .heading-tier--primary{
+      color:var(--accent);
+      font-weight:700;
+      margin:0;
+    }
     /* 佈局：桌機固定兩欄、行動單欄（避免三欄造成橫向拉長） */
     [data-section],
     .page-section,
@@ -603,6 +716,16 @@
     .section-group-body > [data-field-size="long"]{
       flex:1 1 100%;
       min-width:100%;
+    }
+
+    @media (max-width:480px){
+      .row{
+        gap:var(--space-xs);
+      }
+      .row > div{
+        min-width:100%;
+        flex:1 1 100%;
+      }
     }
     
 
@@ -747,13 +870,63 @@
       gap:var(--space-xxs);
       min-width:0;
     }
-    .summary-item.summary-progress{ flex-wrap:wrap; }
+    .summary-item.summary-progress{
+      flex-direction:column;
+      align-items:flex-start;
+      gap:var(--space-xs);
+      padding:var(--space-xs) var(--space-sm);
+      border-radius:var(--radius);
+      border:1px solid transparent;
+      background:rgba(15,23,42,0.02);
+      box-shadow:var(--shadow-soft);
+      min-width:220px;
+    }
     .summary-label{ font-size:0.85rem; color:#475569; font-weight:600; }
+    .summary-item.summary-progress .summary-label{
+      font-size:1rem;
+      color:rgb(17 17 17 / 0.85);
+      font-weight:700;
+    }
     .summary-value{ font-size:1.05rem; font-weight:700; color:rgb(17 17 17 / 0.9); word-break:break-word; }
-    .summary-progress-bar{ position:relative; height:10px; border-radius:999px; background:#e2e8f0; overflow:hidden; min-width:120px; }
-    .summary-progress-fill{ position:absolute; inset:0; width:0%; border-radius:999px; background:var(--accent); transition:width .3s ease; }
+    .summary-progress-bar{ position:relative; height:12px; border-radius:999px; background:#e2e8f0; overflow:hidden; width:100%; }
+    .summary-progress-fill{ position:absolute; inset:0; width:0%; border-radius:999px; background:var(--progress-high); transition:width .3s ease; }
     .summary-progress-text,
-    .summary-remaining-text{ font-weight:600; color:#475569; font-size:0.95rem; }
+    .summary-remaining-text{
+      font-weight:700;
+      color:rgb(17 17 17 / 0.85);
+      font-size:1rem;
+    }
+    .summary-remaining-text{
+      font-size:0.95rem;
+      font-weight:600;
+    }
+    .summary-item.summary-progress[data-progress-state="low"]{
+      background:rgba(220,38,38,0.08);
+      border-color:rgba(220,38,38,0.35);
+    }
+    .summary-item.summary-progress[data-progress-state="mid"]{
+      background:rgba(245,158,11,0.1);
+      border-color:rgba(245,158,11,0.38);
+    }
+    .summary-item.summary-progress[data-progress-state="high"]{
+      background:rgba(22,163,74,0.08);
+      border-color:rgba(22,163,74,0.32);
+    }
+    .summary-progress-text[data-progress-state="low"],
+    .summary-remaining-text[data-progress-state="low"]{
+      color:var(--progress-low);
+    }
+    .summary-progress-text[data-progress-state="mid"],
+    .summary-remaining-text[data-progress-state="mid"]{
+      color:var(--progress-mid);
+    }
+    .summary-progress-text[data-progress-state="high"],
+    .summary-remaining-text[data-progress-state="high"]{
+      color:var(--progress-high);
+    }
+    .summary-progress-fill[data-progress-state="low"]{ background:var(--progress-low); }
+    .summary-progress-fill[data-progress-state="mid"]{ background:var(--progress-mid); }
+    .summary-progress-fill[data-progress-state="high"]{ background:var(--progress-high); }
     .font-scale-control{
       display:inline-flex;
       align-items:center;
@@ -1027,7 +1200,7 @@
     #basicInfoGroup .basic-info-field{
       display:flex;
       flex-direction:column;
-      gap:var(--space-xxs);
+      gap:var(--space-xs);
       min-width:0;
     }
     #basicInfoGroup .basic-info-field label{ margin-bottom:0; }
@@ -1074,7 +1247,7 @@
       border-radius:var(--radius);
       padding:var(--space-sm);
       background:#fff;
-      box-shadow:inset 0 1px 0 rgba(255,255,255,.6);
+      box-shadow:var(--shadow-soft);
       display:flex;
       flex-direction:column;
       gap:var(--space-xs);
@@ -1240,17 +1413,25 @@
     }
 
     .section-progress{
-      margin:12px 0;
+      display:flex;
+      flex-direction:column;
+      gap:var(--space-xxs);
+      margin:0 0 var(--space-md);
+      padding:var(--space-sm);
+      border-radius:var(--radius);
+      border:1px solid rgba(148,163,184,0.32);
+      background:rgba(148,163,184,0.12);
+      box-shadow:var(--shadow-soft);
     }
     .section-progress-text{
-      font-weight:600;
-      color:rgb(17 17 17 / 0.75);
-      margin-bottom:6px;
+      font-weight:700;
+      color:rgb(17 17 17 / 0.85);
+      font-size:1rem;
     }
     .section-progress-bar{
       position:relative;
       width:100%;
-      height:8px;
+      height:12px;
       border-radius:999px;
       background:#e5e7eb;
       overflow:hidden;
@@ -1259,9 +1440,27 @@
       position:absolute;
       inset:0;
       width:0%;
-      background:var(--accent);
-      transition:width .2s ease;
+      background:var(--progress-high);
+      transition:width .25s ease;
     }
+    .section-progress[data-progress-state="low"]{
+      background:rgba(220,38,38,0.08);
+      border-color:rgba(220,38,38,0.35);
+    }
+    .section-progress[data-progress-state="mid"]{
+      background:rgba(245,158,11,0.1);
+      border-color:rgba(245,158,11,0.38);
+    }
+    .section-progress[data-progress-state="high"]{
+      background:rgba(22,163,74,0.08);
+      border-color:rgba(22,163,74,0.32);
+    }
+    .section-progress-text[data-progress-state="low"]{ color:var(--progress-low); }
+    .section-progress-text[data-progress-state="mid"]{ color:var(--progress-mid); }
+    .section-progress-text[data-progress-state="high"]{ color:var(--progress-high); }
+    .section-progress-bar-fill[data-progress-state="low"]{ background:var(--progress-low); }
+    .section-progress-bar-fill[data-progress-state="mid"]{ background:var(--progress-mid); }
+    .section-progress-bar-fill[data-progress-state="high"]{ background:var(--progress-high); }
 
     .section-group{
       border:1px solid var(--border);
@@ -1372,13 +1571,12 @@
 
     /* 需要固定欄寬的首欄位（關係/姓名等） */
     .field-intro{
-      flex:0 0 var(--intro-colw);
-      max-width:var(--intro-colw);
+      max-width:100%;
       min-width:0;
-      width:var(--intro-colw);
+      width:100%;
     }
     .field-intro-grid{
-      grid-template-columns:minmax(var(--intro-colw), var(--intro-colw)) minmax(var(--intro-colw), var(--intro-colw)) minmax(0, 1fr);
+      grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
     }
     .field-intro select,
     .field-intro input[type="text"],
@@ -1527,9 +1725,9 @@
     .field-error{
       color:#b3261e;
       font-size:0.9rem;
-      margin-top:0;
-      align-self:flex-end;
-      text-align:right;
+      margin-top:var(--space-xxs);
+      align-self:flex-start;
+      text-align:left;
       display:none;
       line-height:1.4;
     }
@@ -2063,7 +2261,66 @@
     }
     .side-nav[data-empty="1"]{ display:none; }
     .side-nav-title{ font-weight:700; color:rgb(17 17 17 / 0.9); font-size:1rem; }
-    .side-nav-list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:var(--space-xs); }
+    .side-nav-accordion{
+      display:flex;
+      flex-direction:column;
+      gap:var(--space-sm);
+      margin-top:var(--space-sm);
+    }
+    .side-nav-section{
+      border:1px solid rgba(148,163,184,0.35);
+      border-radius:14px;
+      background:#fff;
+      box-shadow:var(--shadow-soft);
+      overflow:hidden;
+    }
+    .side-nav-section[data-open="0"] .side-nav-list{ display:none; }
+    .side-nav-section-toggle{
+      width:100%;
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      gap:var(--space-xs);
+      padding:var(--space-sm) var(--space-md);
+      background:none;
+      border:none;
+      font-size:1rem;
+      font-weight:700;
+      color:rgb(17 17 17 / 0.85);
+      cursor:pointer;
+      text-align:left;
+    }
+    .side-nav-section-toggle:focus-visible{
+      outline:2px solid var(--accent);
+      outline-offset:2px;
+    }
+    .side-nav-section-toggle[aria-disabled="true"]{
+      cursor:not-allowed;
+      opacity:0.6;
+    }
+    .side-nav-section-toggle::after{
+      content:'▾';
+      font-size:0.9rem;
+      transition:transform .2s ease;
+    }
+    .side-nav-section[data-open="0"] .side-nav-section-toggle::after{
+      transform:rotate(-90deg);
+    }
+    .side-nav-section-summary{
+      font-size:0.9rem;
+      font-weight:600;
+      color:#475569;
+      margin-left:auto;
+    }
+    .side-nav-section-summary[data-progress-state="low"]{ color:var(--progress-low); }
+    .side-nav-section-summary[data-progress-state="mid"]{ color:var(--progress-mid); }
+    .side-nav-section-summary[data-progress-state="high"]{ color:var(--progress-high); }
+    .side-nav-list{ list-style:none; margin:0; padding:var(--space-xs) var(--space-md) var(--space-md); display:flex; flex-direction:column; gap:var(--space-xs); }
+    .side-nav-empty{
+      padding:var(--space-xs) var(--space-sm);
+      font-size:0.9rem;
+      color:#64748b;
+    }
     .side-nav-item{
       display:flex;
       align-items:center;
@@ -2477,12 +2734,28 @@
     .home-care-grid,
     .checkgrid{
       display:grid;
-      gap:var(--space-sm);
+      gap:var(--space-md);
       grid-template-columns:repeat(auto-fill, minmax(var(--card-grid-min, var(--card-col-min)), var(--card-col-max)));
       align-items:start;
     }
 
     .checkgrid{ --card-grid-min:var(--checkcol-min); }
+
+    #contactVisitGroup .section-card-grid{
+      grid-template-columns:1fr;
+    }
+
+    @media (min-width:640px){
+      #contactVisitGroup .section-card-grid{
+        grid-template-columns:repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width:1024px){
+      #contactVisitGroup .section-card-grid{
+        grid-template-columns:repeat(3, minmax(0, 1fr));
+      }
+    }
 
     .cards-2{
       grid-template-columns:repeat(2, minmax(var(--card-grid-min, var(--card-col-min)), var(--card-col-max)));
@@ -2556,6 +2829,16 @@
 
   <div class="app-container" id="appContainer">
     <div class="app-shell">
+      <div class="global-banner" id="globalBanner" data-visible="0" data-type="info" role="status" aria-live="polite">
+        <div class="global-banner-content">
+          <div class="global-banner-title" id="globalBannerTitle">提醒</div>
+          <div class="global-banner-text" id="globalBannerText"></div>
+        </div>
+        <div class="global-banner-actions">
+          <button type="button" class="global-banner-action" id="globalBannerAction">前往</button>
+          <button type="button" class="global-banner-close" id="globalBannerClose" aria-label="關閉通知">關閉</button>
+        </div>
+      </div>
       <header class="app-header">
         <div class="app-sticky" id="appSticky" data-expanded="0">
           <div class="app-sticky-inner">
@@ -2625,7 +2908,7 @@
         <div class="side-nav-backdrop" id="sideNavBackdrop" role="presentation" aria-hidden="true"></div>
         <nav class="side-nav" id="sideNav" aria-label="群組導覽" data-empty="1" tabindex="-1">
           <div class="side-nav-title">群組導覽</div>
-          <ul class="side-nav-list" id="sideNavList"></ul>
+          <div class="side-nav-accordion" id="sideNavAccordion"></div>
         </nav>
         <main class="app-main" id="appMain">
           <div class="page-section" data-page="basic" data-active="1" data-columns="1">
@@ -4163,12 +4446,25 @@
       progressText:'summaryProgressText',
       remainingText:'summaryRemainingText'
     };
+    const GLOBAL_BANNER_IDS = {
+      root:'globalBanner',
+      title:'globalBannerTitle',
+      text:'globalBannerText',
+      action:'globalBannerAction',
+      close:'globalBannerClose'
+    };
     const PAGE_LABELS = {
       basic:'基本資訊',
       goals:'計畫目標',
       execution:'計畫執行規劃',
       notes:'其他備註'
     };
+    const SIDE_NAV_SECTION_CONFIG = [
+      { id:'basic', label:'基本資訊' },
+      { id:'goals', label:'計畫目標' },
+      { id:'overview', label:'個案概況' },
+      { id:'others', label:'其他模組' }
+    ];
 
     const HEADING_SCHEMA_VERSION = '2025-10-15';
     const HEADING_SCHEMA_VERSION_STORAGE_KEY = 'AA01.headingSchema.version';
@@ -4385,6 +4681,7 @@
           assignHeadingEntries(entry.children, node);
         }
       });
+      updateSideNavSectionSummaries();
     }
 
     function rebuildHeadingIndex(schema){
@@ -4517,7 +4814,13 @@
     function focusFirstSideNavItem(){
       const nav=document.getElementById('sideNav');
       if(!nav) return;
-      const focusable=nav.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      let focusable=nav.querySelector('.side-nav-link');
+      if(!focusable){
+        focusable = nav.querySelector('.side-nav-section-toggle');
+      }
+      if(!focusable){
+        focusable = nav.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      }
       if(focusable && typeof focusable.focus === 'function'){
         focusable.focus();
       }else if(typeof nav.focus === 'function'){
@@ -5770,12 +6073,14 @@
 
     const PAGE_ORDER = ['basic','goals','execution','notes'];
     let summaryElements = null;
+    let globalBannerElements = null;
     let lastSavedTimestamp = null;
 
     const SIDE_NAV_STATE = {
       root:null,
-      list:null,
-      items:[]
+      accordion:null,
+      items:[],
+      sections:{}
     };
     const Scheduler = (function(){
       let rafId = 0;
@@ -6456,6 +6761,7 @@
       const progress = getGlobalProgressState();
       const hasRequired = !!(progress.required);
       const remainingCount = hasRequired ? Math.max(0, (progress.required || 0) - (progress.filled || 0)) : 0;
+      const progressItem = els.root ? els.root.querySelector('.summary-item.summary-progress') : null;
       if(els.progressFill) els.progressFill.style.width = `${progress.percent || 0}%`;
       if(els.progressText){
         if(hasRequired){
@@ -6475,6 +6781,12 @@
           els.remainingText.textContent = '—';
         }
       }
+      applyProgressState([
+        els.progressFill,
+        els.progressText,
+        els.remainingText,
+        progressItem
+      ], progress.percent || 0);
     }
 
     function scheduleSummaryUpdate(){
@@ -6488,7 +6800,8 @@
     function getSideNavElements(){
       if(!SIDE_NAV_STATE.root){
         SIDE_NAV_STATE.root = document.getElementById('sideNav');
-        SIDE_NAV_STATE.list = document.getElementById('sideNavList');
+        SIDE_NAV_STATE.accordion = document.getElementById('sideNavAccordion');
+        SIDE_NAV_STATE.sections = {};
       }
       return SIDE_NAV_STATE;
     }
@@ -6515,6 +6828,35 @@
 
     function formatSideNavCount(filled, required){
       return formatProgressDisplay(filled, required);
+    }
+
+    function resolveProgressState(percent){
+      const value = Number(percent);
+      if(!Number.isFinite(value)) return 'low';
+      if(value >= 70) return 'high';
+      if(value >= 30) return 'mid';
+      return 'low';
+    }
+
+    function applyProgressState(targets, percent){
+      const state = resolveProgressState(percent);
+      if(!targets) return state;
+      const list = Array.isArray(targets) ? targets : [targets];
+      list.forEach(el=>{
+        if(!el || !el.dataset) return;
+        el.dataset.progressState = state;
+      });
+      return state;
+    }
+
+    function resolveSideNavCategory(item){
+      if(!item) return 'others';
+      const page = (item.pageId || '').toString();
+      const anchor = (item.anchorId || item.headingId || '').toString();
+      if(page === 'basic') return 'basic';
+      if(anchor === 'h2-goals-overview' || /^h3-goals-s\d+/.test(anchor)) return 'overview';
+      if(page === 'goals') return 'goals';
+      return 'others';
     }
 
     function scrollToAnchorId(anchorId, options){
@@ -6620,8 +6962,10 @@
 
     function renderSideNav(){
       const state = getSideNavElements();
-      if(!state.root || !state.list) return;
-      state.list.innerHTML='';
+      if(!state.root || !state.accordion) return;
+      const previousSections = state.sections || {};
+      state.accordion.innerHTML='';
+      state.sections = {};
       const activePage = currentPageId || '';
       state.root.dataset.page = activePage;
       if(state.items && state.items.length){
@@ -6643,35 +6987,140 @@
         return;
       }
       state.root.dataset.empty = '0';
+      const buckets = {};
+      SIDE_NAV_SECTION_CONFIG.forEach(cfg=>{ buckets[cfg.id] = []; });
       visibleItems.forEach(item=>{
-        const li=document.createElement('li');
-        li.className='side-nav-item';
-        li.dataset.page = item.pageId || '';
-        li.dataset.level = String(item.level || 2);
-        const btn=document.createElement('button');
-        btn.type='button';
-        btn.className='side-nav-link';
-        btn.textContent=item.label || '未命名群組';
-        btn.dataset.target=item.anchorId || '';
-        btn.dataset.page=item.pageId || '';
-        btn.dataset.level = String(item.level || 2);
-        btn.addEventListener('click', handleSideNavClick);
-        const count=document.createElement('span');
-        count.className='side-nav-count';
-        const stats=item.stats || { filled:0, required:0 };
-        const status=item.status || determineProgressStatus(stats.filled || 0, stats.required || 0);
-        item.status = status;
-        count.textContent = formatSideNavCount(stats.filled || 0, stats.required || 0);
-        li.dataset.status = status;
-        btn.dataset.status = status;
-        li.appendChild(btn);
-        li.appendChild(count);
-        state.list.appendChild(li);
-        item.element = li;
-        item.button = btn;
-        item.countEl = count;
+        if(!item) return;
+        const category = item.category || resolveSideNavCategory(item);
+        const targetCategory = buckets[category] ? category : 'others';
+        item.category = targetCategory;
+        buckets[targetCategory] = buckets[targetCategory] || [];
+        buckets[targetCategory].push(item);
       });
+      SIDE_NAV_SECTION_CONFIG.forEach(cfg=>{
+        const sectionItems = buckets[cfg.id] || [];
+        const sectionEl=document.createElement('section');
+        sectionEl.className='side-nav-section';
+        sectionEl.dataset.sectionId = cfg.id;
+        const prev = previousSections[cfg.id];
+        const toggle=document.createElement('button');
+        toggle.type='button';
+        toggle.className='side-nav-section-toggle';
+        toggle.dataset.sectionId = cfg.id;
+        const labelSpan=document.createElement('span');
+        labelSpan.textContent = cfg.label;
+        toggle.appendChild(labelSpan);
+        const summary=document.createElement('span');
+        summary.className='side-nav-section-summary';
+        toggle.appendChild(summary);
+        sectionEl.appendChild(toggle);
+        const list=document.createElement('ul');
+        list.className='side-nav-list';
+        sectionEl.appendChild(list);
+        const sectionState={ element:sectionEl, toggle, summary, list, items:sectionItems, open:true };
+        const defaultOpen = sectionItems.length > 0;
+        const open = prev && typeof prev.open === 'boolean' ? prev.open : defaultOpen;
+        sectionState.open = open;
+        sectionEl.dataset.open = open ? '1' : '0';
+        toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+        toggle.addEventListener('click', ()=>{
+          if(toggle.disabled) return;
+          const nextOpen = sectionEl.dataset.open !== '1';
+          sectionEl.dataset.open = nextOpen ? '1' : '0';
+          toggle.setAttribute('aria-expanded', nextOpen ? 'true' : 'false');
+          sectionState.open = nextOpen;
+        });
+        if(sectionItems.length){
+          sectionItems.forEach(item=>{
+            const li=document.createElement('li');
+            li.className='side-nav-item';
+            li.dataset.page = item.pageId || '';
+            li.dataset.level = String(item.level || 2);
+            const btn=document.createElement('button');
+            btn.type='button';
+            btn.className='side-nav-link';
+            btn.textContent=item.label || '未命名群組';
+            btn.dataset.target=item.anchorId || '';
+            btn.dataset.page=item.pageId || '';
+            btn.dataset.level = String(item.level || 2);
+            btn.addEventListener('click', handleSideNavClick);
+            const count=document.createElement('span');
+            count.className='side-nav-count';
+            const stats=item.stats || { filled:0, required:0 };
+            const status=item.status || determineProgressStatus(stats.filled || 0, stats.required || 0);
+            item.status = status;
+            count.textContent = formatSideNavCount(stats.filled || 0, stats.required || 0);
+            li.dataset.status = status;
+            btn.dataset.status = status;
+            li.appendChild(btn);
+            li.appendChild(count);
+            list.appendChild(li);
+            item.element = li;
+            item.button = btn;
+            item.countEl = count;
+          });
+          toggle.disabled = false;
+          toggle.setAttribute('aria-disabled','false');
+          sectionEl.dataset.empty = '0';
+        }else{
+          const empty=document.createElement('li');
+          empty.className='side-nav-empty';
+          empty.textContent='暫無項目';
+          list.appendChild(empty);
+          toggle.disabled = true;
+          toggle.setAttribute('aria-disabled','true');
+          sectionEl.dataset.empty = '1';
+          sectionEl.dataset.open = '0';
+          toggle.setAttribute('aria-expanded', 'false');
+          sectionState.open = false;
+        }
+        state.accordion.appendChild(sectionEl);
+        state.sections[cfg.id] = sectionState;
+      });
+      updateSideNavSectionSummaries();
       scheduleAllMeasurements();
+    }
+
+    function updateSideNavSectionSummaries(){
+      const state = getSideNavElements();
+      if(!state.sections) return;
+      SIDE_NAV_SECTION_CONFIG.forEach(cfg=>{
+        const sectionState = state.sections[cfg.id];
+        if(!sectionState || !sectionState.summary) return;
+        const items = Array.isArray(sectionState.items) ? sectionState.items : [];
+        if(!items.length){
+          sectionState.summary.textContent = '尚無項目';
+          applyProgressState([sectionState.summary, sectionState.element], 0);
+          if(sectionState.element && sectionState.element.dataset){
+            sectionState.element.dataset.empty = '1';
+          }
+          return;
+        }
+        let requiredTotal = 0;
+        let filledTotal = 0;
+        items.forEach(item=>{
+          if(!item) return;
+          const stats=item.stats || { filled:0, required:0 };
+          requiredTotal += stats.required || 0;
+          filledTotal += stats.filled || 0;
+        });
+        const percent = requiredTotal
+          ? Math.round((filledTotal / Math.max(1, requiredTotal)) * 100)
+          : (filledTotal > 0 ? 100 : 0);
+        let summaryText = '';
+        if(requiredTotal){
+          summaryText = `完成度 ${percent}%`;
+        }else if(filledTotal){
+          summaryText = `已填 ${filledTotal}`;
+        }else{
+          summaryText = '待填寫';
+        }
+        sectionState.summary.textContent = summaryText;
+        applyProgressState([sectionState.summary, sectionState.element], percent);
+        if(sectionState.element && sectionState.element.dataset){
+          sectionState.element.dataset.empty = '0';
+        }
+      });
     }
 
     function getWizardJumpSelect(){
@@ -6728,7 +7177,7 @@
 
     function registerSideNavGroups(){
       const state = getSideNavElements();
-      if(!state.root || !state.list) return;
+      if(!state.root || !state.accordion) return;
       const items=[];
       forEachHeading(function(entry){
         if(!entry || entry.level <= 1) return;
@@ -6756,8 +7205,10 @@
           status: status,
           element:null,
           button:null,
-          countEl:null
+          countEl:null,
+          category:null
         };
+        item.category = resolveSideNavCategory(item);
         if(group){
           group.navItem = item;
         }
@@ -7850,6 +8301,11 @@
         if(!Number.isFinite(percent)) percent = 100;
         progress.text.textContent = `已完成 ${filledCount} / ${requiredCount}（${percent}%）`;
         progress.bar.style.width = `${percent}%`;
+        applyProgressState([
+          progress.element,
+          progress.text,
+          progress.bar
+        ], percent);
       }
       (section.__groups || []).forEach(group=>{
         if(!group || !group.element) return;
@@ -15938,6 +16394,84 @@
       return ordered;
     }
 
+    function getGlobalBannerElements(){
+      if(globalBannerElements) return globalBannerElements;
+      const root=document.getElementById(GLOBAL_BANNER_IDS.root);
+      if(!root){
+        globalBannerElements = { root:null, title:null, text:null, action:null, close:null };
+        return globalBannerElements;
+      }
+      globalBannerElements = {
+        root:root,
+        title:document.getElementById(GLOBAL_BANNER_IDS.title),
+        text:document.getElementById(GLOBAL_BANNER_IDS.text),
+        action:document.getElementById(GLOBAL_BANNER_IDS.action),
+        close:document.getElementById(GLOBAL_BANNER_IDS.close)
+      };
+      if(globalBannerElements.close){
+        globalBannerElements.close.addEventListener('click', ()=>hideGlobalBanner());
+      }
+      if(globalBannerElements.action){
+        globalBannerElements.action.addEventListener('click', handleGlobalBannerAction);
+      }
+      return globalBannerElements;
+    }
+
+    function hideGlobalBanner(){
+      const els=getGlobalBannerElements();
+      if(!els.root) return;
+      els.root.dataset.visible='0';
+      els.root.dataset.target='';
+      els.root.dataset.page='';
+      els.root.dataset.step='';
+      if(els.action){
+        els.action.style.display='none';
+      }
+    }
+
+    function showGlobalBanner(options){
+      const els=getGlobalBannerElements();
+      if(!els.root) return;
+      const payload=options || {};
+      const message=payload.message || '';
+      if(!message){
+        hideGlobalBanner();
+        return;
+      }
+      const type=payload.type || 'info';
+      if(els.title){
+        const defaultTitle = type === 'error' ? '錯誤' : (type === 'warn' ? '提醒' : '通知');
+        els.title.textContent = payload.title || defaultTitle;
+      }
+      if(els.text){
+        els.text.textContent = message;
+      }
+      els.root.dataset.type = type;
+      els.root.dataset.visible = '1';
+      els.root.dataset.target = payload.target || '';
+      els.root.dataset.page = payload.page || '';
+      els.root.dataset.step = (payload.step !== undefined && payload.step !== null) ? String(payload.step) : '';
+      if(els.action){
+        const hasTarget = !!(payload.target || payload.page || payload.step);
+        els.action.style.display = hasTarget ? '' : 'none';
+      }
+    }
+
+    function handleGlobalBannerAction(){
+      const els=getGlobalBannerElements();
+      if(!els.root) return;
+      const pageId=els.root.dataset.page || '';
+      const stepValue=els.root.dataset.step || '';
+      const targetId=els.root.dataset.target || '';
+      hideGlobalBanner();
+      if(pageId){
+        setActivePage(pageId, { step: stepValue ? Number(stepValue) : undefined });
+      }else if(stepValue){
+        setCurrentWizardStep(Number(stepValue), { scroll:false });
+      }
+      focusErrorTarget(targetId);
+    }
+
     function renderErrorSummary(messages){
       const box=document.getElementById('errorSummary');
       if(!box) return;
@@ -15997,6 +16531,14 @@
       if(actionBtn){
         actionBtn.style.display = payload.target ? '' : 'none';
       }
+      showGlobalBanner({
+        type:type,
+        message:message,
+        target:payload.target,
+        page:payload.page,
+        step:payload.step,
+        title:payload.bannerTitle
+      });
     }
 
     function hideValidationToast(){
@@ -16015,6 +16557,7 @@
       const toast=document.getElementById('validationToast');
       if(!toast) return;
       hideValidationToast();
+      hideGlobalBanner();
       const action=document.getElementById('validationToastAction');
       if(action){
         action.addEventListener('click', ()=>{


### PR DESCRIPTION
## Summary
- redesign the contact visit cards into responsive cards with consistent spacing and full-width form controls across breakpoints
- introduce a top global notification banner, progress bar theming, and accordion-based side navigation that adapts for desktop and mobile triggers
- add clearer section dividers and inline validation styling within the case overview and other form blocks

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dcce8d5c6c832b86241c4b1df24042