### PR TITLE
Refine wizard layout responsiveness

### DIFF
--- a/src/Sidebar.html
+++ b/src/Sidebar.html
@@ -71,8 +71,8 @@
       --side-nav-w:280px;
       --sticky-padding-block:var(--space-xs);
       --sticky-padding-inline:clamp(10px, 3.2vw, 18px);
-      --wizard-index-size:34px;
-      --wizard-index-font:0.95rem;
+      --wizard-index-size:clamp(32px, 4vw, 40px);
+      --wizard-index-font:clamp(0.85rem, 2.1vw, 1rem);
       --group-header-spacing:var(--space-xs);
       --bottom-bar-min-height:48px;
       --layout-max:1440px;
@@ -106,22 +106,26 @@
       .summary-value{ font-size:1.05rem; }
 
       .wizard{
-        overflow-x:auto;
-        gap:var(--space-xs);
-        padding-bottom:4px;
-        scroll-snap-type:x proximity;
-        -webkit-overflow-scrolling:touch;
+        grid-template-columns:repeat(auto-fit, minmax(180px, 1fr));
+        gap:var(--space-sm);
+        padding-bottom:0;
+        overflow:visible;
+        scroll-snap-type:none;
       }
-      .wizard::-webkit-scrollbar{ height:6px; }
       .wizard-step{
-        flex:0 0 auto;
-        min-width:140px;
+        min-width:0;
         align-items:flex-start;
-        scroll-snap-align:center;
       }
-      .wizard-step::before{ display:none; }
-      .wizard-label{ text-align:left; white-space:normal; font-size:0.92rem; }
-      .wizard-index{ width:32px; height:32px; font-size:0.9rem; }
+      .wizard-label{
+        text-align:left;
+        white-space:normal;
+        font-size:0.95rem;
+      }
+      .wizard-index{
+        width:var(--wizard-index-size);
+        height:var(--wizard-index-size);
+        font-size:var(--wizard-index-font);
+      }
       .wizard-quickjump label{ display:none; }
     
       .cms-level-group{
@@ -786,6 +790,17 @@
     }
     button:hover{ background:#f7f7f7; }
     button.primary{ background:var(--accent); color:#fff; border-color:var(--accent); }
+    button.primary:hover{ background:#0a4dc2; border-color:#0a4dc2; }
+    button.secondary{
+      background:#fff;
+      color:var(--accent);
+      border-color:rgba(11,87,208,.55);
+      box-shadow:none;
+    }
+    button.secondary:hover{
+      background:rgba(11,87,208,.08);
+      border-color:var(--accent);
+    }
     button.button-add,
     button[data-variant="add"]{
       background:var(--accent);
@@ -879,7 +894,8 @@
       border:1px solid transparent;
       background:rgba(15,23,42,0.02);
       box-shadow:var(--shadow-soft);
-      min-width:220px;
+      min-width:240px;
+      width:100%;
     }
     .summary-label{ font-size:0.85rem; color:#475569; font-weight:600; }
     .summary-item.summary-progress .summary-label{
@@ -888,7 +904,7 @@
       font-weight:700;
     }
     .summary-value{ font-size:1.05rem; font-weight:700; color:rgb(17 17 17 / 0.9); word-break:break-word; }
-    .summary-progress-bar{ position:relative; height:12px; border-radius:999px; background:#e2e8f0; overflow:hidden; width:100%; }
+    .summary-progress-bar{ position:relative; height:16px; border-radius:999px; background:#e2e8f0; overflow:hidden; width:100%; }
     .summary-progress-fill{ position:absolute; inset:0; width:0%; border-radius:999px; background:var(--progress-high); transition:width .3s ease; }
     .summary-progress-text,
     .summary-remaining-text{
@@ -995,17 +1011,22 @@
       color:#fff;
       border-color:var(--accent);
     }
+    .wizard-wrapper{
+      display:flex;
+      flex-direction:column;
+      gap:var(--space-sm);
+      flex:1 1 auto;
+      min-width:0;
+    }
     .wizard{
       position:relative;
-      display:flex;
-      justify-content:flex-start;
-      align-items:center;
+      display:grid;
+      grid-template-columns:repeat(auto-fit, minmax(160px, 1fr));
+      align-items:stretch;
       gap:var(--space-sm);
-      flex-wrap:wrap;
     }
     .wizard-step{
       position:relative;
-      flex:1 1 160px;
       display:flex;
       flex-direction:column;
       align-items:center;
@@ -1078,11 +1099,59 @@
       background:rgba(11,87,208,.12);
       box-shadow:0 0 0 1px rgba(11,87,208,.18);
     }
+    .wizard-step[data-status="active"]::after{
+      content:'';
+      position:absolute;
+      left:12px;
+      right:12px;
+      bottom:-3px;
+      height:6px;
+      background:var(--accent);
+      border-radius:999px;
+    }
     .wizard-step[data-status="active"] .wizard-index{
       transform:scale(1.05);
     }
     .wizard-step[data-status="active"] .wizard-label{ color:var(--accent); }
     .wizard-step[data-status="done"] .wizard-label{ color:rgb(var(--status-complete) / 1); }
+
+    .wizard-status-card{
+      display:grid;
+      gap:var(--space-xs);
+      padding:var(--space-sm);
+      border-radius:var(--radius);
+      border:1px solid var(--border);
+      background:#f8fbff;
+      box-shadow:var(--shadow-soft);
+      min-width:0;
+    }
+    .wizard-current-step{
+      display:flex;
+      flex-wrap:wrap;
+      align-items:center;
+      gap:var(--space-xs);
+    }
+    .wizard-current-step-label{
+      font-size:0.9rem;
+      font-weight:600;
+      color:#475569;
+    }
+    .wizard-current-step-value{
+      font-size:1.05rem;
+      font-weight:700;
+      color:var(--accent);
+    }
+    .wizard-current-step-meta{
+      font-size:0.85rem;
+      font-weight:600;
+      color:#64748b;
+    }
+    .summary-progress-details{
+      display:flex;
+      flex-wrap:wrap;
+      align-items:center;
+      gap:var(--space-xs);
+    }
     
     .page-section{
       display:none;
@@ -1186,10 +1255,44 @@
       border-color:var(--accent);
     }
 
+    @media (max-width:900px){
+      .wizard{
+        grid-template-columns:repeat(auto-fit, minmax(200px, 1fr));
+        gap:var(--space-sm);
+      }
+      .wizard-step::before{ display:none; }
+    }
+    @media (max-width:720px){
+      .wizard{ gap:var(--space-xs); grid-template-columns:repeat(auto-fit, minmax(180px, 1fr)); }
+    }
+    @media (max-width:600px){
+      .wizard{ grid-template-columns:repeat(auto-fit, minmax(200px, 1fr)); }
+      .wizard-wrapper{ gap:var(--space-xs); }
+      .wizard-status-card{ padding:var(--space-xs); }
+      .floating-actions{ justify-content:flex-end; gap:var(--space-xs); }
+      .floating-actions button{ flex:0 1 auto; min-width:140px; }
+    }
+    @media (max-width:540px){
+      .wizard{
+        grid-template-columns:1fr;
+        gap:var(--space-xs);
+      }
+      .wizard-step{
+        flex-direction:row;
+        justify-content:flex-start;
+        gap:var(--space-sm);
+      }
+      .wizard-step::before{ display:none; }
+      .wizard-step[data-status="active"]::after{ display:none; }
+      .wizard-index{ flex-shrink:0; }
+      .wizard-label{ text-align:left; }
+      .wizard-status-card{ gap:var(--space-xs); }
+    }
+
     #basicInfoGroup .basic-info-fields{
       display:flex;
       flex-direction:column;
-      gap:var(--space-xs);
+      gap:var(--space-xxs);
     }
     #basicInfoGroup .basic-info-row{
       display:flex;
@@ -1200,7 +1303,7 @@
     #basicInfoGroup .basic-info-field{
       display:flex;
       flex-direction:column;
-      gap:var(--space-xs);
+      gap:var(--space-xxs);
       min-width:0;
     }
     #basicInfoGroup .basic-info-field label{ margin-bottom:0; }
@@ -1567,6 +1670,36 @@
     .checkcol label[data-auto="1"]{
       border-color:rgba(11,87,208,.4);
       background:rgba(11,87,208,0.08);
+    }
+
+    .field-hint{
+      margin:0;
+      font-size:0.85rem;
+      color:#64748b;
+      line-height:1.45;
+    }
+    .field-required{
+      color:#dc2626;
+      font-weight:700;
+      margin-left:4px;
+    }
+    .search-control{
+      display:flex;
+      width:100%;
+      margin-top:var(--space-xxs);
+    }
+    .search-control input[type="search"]{
+      width:100%;
+      min-height:var(--h-button-sm);
+      padding:var(--ctrl-padding-block) var(--ctrl-padding-inline);
+      border-radius:10px;
+      border:1px solid var(--border);
+      font-size:var(--fs-ctrl);
+    }
+    .search-control input[type="search"]:focus{
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:0 0 0 3px var(--accent-weak);
     }
 
     /* 需要固定欄寬的首欄位（關係/姓名等） */
@@ -2764,7 +2897,7 @@
     .section-card{
       display:flex;
       flex-direction:column;
-      gap:var(--space-sm);
+      gap:var(--space-xs);
       break-inside:avoid;
       -webkit-column-break-inside:avoid;
       page-break-inside:avoid;
@@ -2781,7 +2914,7 @@
     }
     .autogrid{
       display:grid;
-      gap:var(--autogrid-gap, var(--space-sm));
+      gap:var(--autogrid-gap, clamp(var(--space-xxs), 2vw, var(--space-sm)));
       grid-template-columns:repeat(auto-fit, minmax(var(--col-min, 280px), 1fr));
       align-items:start;
     }
@@ -2844,7 +2977,8 @@
           <div class="app-sticky-inner">
             <div class="sticky-header">
               <div class="sticky-header-row">
-                <div class="wizard" id="wizardSteps" aria-label="填寫進度" role="tablist" aria-orientation="horizontal">
+                <div class="wizard-wrapper">
+                  <div class="wizard" id="wizardSteps" aria-label="填寫進度" role="tablist" aria-orientation="horizontal">
                   <button type="button" class="wizard-step" data-step="1" data-page="basic" data-anchor="#basicInfoGroup" role="tab" aria-selected="false" aria-current="false" tabindex="-1">
                     <span class="wizard-index">1</span>
                     <span class="wizard-label">基本資訊</span>
@@ -2861,6 +2995,24 @@
                     <span class="wizard-index">4</span>
                     <span class="wizard-label">其他備註</span>
                   </button>
+                  </div>
+                  <div class="wizard-status-card" id="wizardStatusCard">
+                    <div class="wizard-current-step" id="wizardCurrentStep" aria-live="polite">
+                      <span class="wizard-current-step-label">目前步驟</span>
+                      <span class="wizard-current-step-value" id="wizardCurrentStepLabel">步驟 1：基本資訊</span>
+                      <span class="wizard-current-step-meta" id="wizardCurrentStepMeta">共 4 步</span>
+                    </div>
+                    <div class="summary-item summary-progress">
+                      <span class="summary-label">完成度</span>
+                      <div class="summary-progress-bar" role="presentation">
+                        <div class="summary-progress-fill" id="summaryProgressFill"></div>
+                      </div>
+                      <div class="summary-progress-details">
+                        <span class="summary-progress-text" id="summaryProgressText">—</span>
+                        <span class="summary-remaining-text" id="summaryRemainingText">—</span>
+                      </div>
+                    </div>
+                  </div>
                 </div>
                 <div class="sticky-controls" id="pageToolbar">
                   <div class="font-scale-control" id="fontScaleControl" role="group" aria-label="字級設定">
@@ -2884,14 +3036,6 @@
                 <div class="summary-item">
                   <span class="summary-label">CMS 等級</span>
                   <span class="summary-value" id="summaryCmsLevel">—</span>
-                </div>
-                <div class="summary-item summary-progress">
-                  <span class="summary-label">完成度</span>
-                  <div class="summary-progress-bar" role="presentation">
-                    <div class="summary-progress-fill" id="summaryProgressFill"></div>
-                  </div>
-                  <span class="summary-progress-text" id="summaryProgressText">—</span>
-                  <span class="summary-remaining-text" id="summaryRemainingText">—</span>
                 </div>
               </div>
             </div>
@@ -2926,36 +3070,46 @@
             </div>
             <div class="basic-info-fields">
               <div class="basic-info-row" data-row="1">
-                <div class="basic-info-field unit-code-field field-intro" data-field-size="short">
-                  <label class="h3" for="unitCode">單位代碼</label>
-                  <select id="unitCode">
+                <div class="basic-info-field unit-code-field field-intro" data-field-size="short" data-basic-required="1">
+                  <label class="h3" for="unitCode">單位代碼<span class="field-required" aria-hidden="true">*</span><span class="sr-only">（必填）</span></label>
+                  <select id="unitCode" aria-describedby="unitCodeHint">
                     <option>FNA1</option><option>FNA2</option><option>FNA3</option>
                   </select>
+                  <p class="field-hint" id="unitCodeHint">請選擇本次要處理的單位代碼，系統會依此載入個管師與照專名單。</p>
                 </div>
                 <div class="basic-info-field case-manager-field field-intro" data-field-size="medium" data-basic-required="1">
-                  <label class="h3" for="caseManagerName">個案管理師</label>
-                  <select id="caseManagerName">
+                  <label class="h3" for="caseManagerName">個案管理師<span class="field-required" aria-hidden="true">*</span><span class="sr-only">（必填）</span></label>
+                  <div class="search-control">
+                    <input type="search" id="caseManagerFilter" placeholder="輸入姓名或關鍵字搜尋" aria-label="搜尋個案管理師" autocomplete="off">
+                  </div>
+                  <select id="caseManagerName" aria-describedby="caseManagerHint">
                     <option value="" class="placeholder-option" disabled selected>請選擇</option>
                   </select>
+                  <p class="field-hint" id="caseManagerHint">支援即時搜尋，輸入姓氏或職稱關鍵字即可快速篩選名單。</p>
                   <div class="basic-info-status" id="caseManagerStatus" role="status" aria-live="polite"></div>
                 </div>
               </div>
               <div class="basic-info-row" data-row="2">
                 <div class="basic-info-field case-name-field field-intro" data-field-size="medium" data-basic-required="1">
-                  <label class="h3" for="caseName">個案姓名</label>
-                  <input id="caseName" type="text" placeholder="請輸入">
+                  <label class="h3" for="caseName">個案姓名<span class="field-required" aria-hidden="true">*</span><span class="sr-only">（必填）</span></label>
+                  <input id="caseName" type="text" placeholder="請輸入" aria-describedby="caseNameHint">
+                  <p class="field-hint" id="caseNameHint">請填寫證件上的正式姓名，避免使用暱稱或別名，便於與附件資料對應。</p>
                   <div class="basic-info-status" id="caseNameStatus" role="status" aria-live="polite"></div>
                 </div>
                 <div class="basic-info-field consult-name-field field-intro" data-field-size="medium" data-basic-required="1">
-                  <label class="h3" for="consultName">照專姓名</label>
-                  <select id="consultName">
+                  <label class="h3" for="consultName">照專姓名<span class="field-required" aria-hidden="true">*</span><span class="sr-only">（必填）</span></label>
+                  <div class="search-control">
+                    <input type="search" id="consultFilter" placeholder="輸入姓名或關鍵字搜尋" aria-label="搜尋照專姓名" autocomplete="off">
+                  </div>
+                  <select id="consultName" aria-describedby="consultNameHint">
                     <option value="" class="placeholder-option" disabled selected>請選擇</option>
                   </select>
+                  <p class="field-hint" id="consultNameHint">可輸入姓名或單位關鍵字過濾列表，協助快速找到對應的照專。</p>
                   <div class="basic-info-status" id="consultStatus" role="status" aria-live="polite"></div>
                 </div>
               </div>
               <div class="cms-level-row" data-row="3" data-basic-required="1">
-                <label class="h3" for="cmsLevelValue">CMS 等級</label>
+                <label class="h3" for="cmsLevelValue">CMS 等級<span class="field-required" aria-hidden="true">*</span><span class="sr-only">（必填）</span></label>
                 <div id="cmsLevelGroup" class="cms-level-group">
                   <button type="button" data-level="2">2</button>
                   <button type="button" data-level="3">3</button>
@@ -2965,7 +3119,7 @@
                   <button type="button" data-level="7">7</button>
                   <button type="button" data-level="8">8</button>
                 </div>
-                <div class="hint cms-level-hint">選擇 CMS 等級後會同步填入隱藏欄位。</div>
+                <p class="field-hint cms-level-hint hint">選擇 CMS 等級後會同步填入隱藏欄位並更新附件計算基準。</p>
                 <div class="basic-info-status" id="cmsLevelStatus" role="status" aria-live="polite"></div>
                 <input type="hidden" id="cmsLevelValue" value="">
               </div>
@@ -4395,14 +4549,14 @@
       </div>
 
       <div class="floating-actions" id="floatingActions" aria-label="頁面操作">
-        <button type="button" class="primary" id="wizardSaveBtn" data-action="apply-and-save">存檔</button>
+        <button type="button" class="secondary" id="wizardSaveBtn" data-action="apply-and-save">存檔</button>
         <div id="wizardMoreWrapper">
           <button type="button" id="wizardMoreBtn" aria-haspopup="true" aria-expanded="false" aria-controls="wizardMoreMenu" aria-label="更多操作" title="更多操作">⋯</button>
           <div class="floating-more-menu" id="wizardMoreMenu" role="menu" data-open="0">
             <button type="button" class="small" id="wizardPrevCompactBtn" role="menuitem">返回</button>
           </div>
         </div>
-        <button type="button" id="wizardNextBtn">下一步</button>
+        <button type="button" class="primary" id="wizardNextBtn">下一步</button>
         <button type="button" data-variant="ghost" id="wizardPrevBtn">返回</button>
       </div>
 
@@ -8655,6 +8809,54 @@
     }
 
 
+    function filterSelectOptionsByTerm(select, term){
+      if(!select || !select.options) return;
+      const normalized=String(term || '').trim().toLowerCase();
+      const options=Array.from(select.options);
+      let hasMatch=false;
+      options.forEach((option, index)=>{
+        if(index===0){
+          option.hidden=false;
+          return;
+        }
+        const text=(option.textContent || '').toLowerCase();
+        const match=!normalized || text.includes(normalized);
+        option.hidden=!match;
+        if(match){ hasMatch=true; }
+      });
+      if(select.selectedIndex > 0){
+        const current=select.options[select.selectedIndex];
+        if(current && current.hidden){
+          select.selectedIndex=0;
+        }
+      }
+      select.dataset.hasMatches = hasMatch ? '1' : '0';
+    }
+
+    function refreshSearchableSelect(selectId, filterId){
+      const select=document.getElementById(selectId);
+      const filter=document.getElementById(filterId);
+      if(!select || !filter) return;
+      filterSelectOptionsByTerm(select, filter.value || '');
+    }
+
+    function setupSearchableSelect(selectId, filterId){
+      const select=document.getElementById(selectId);
+      const filter=document.getElementById(filterId);
+      if(!select || !filter) return;
+      if(filter.dataset.searchAttached === '1'){
+        refreshSearchableSelect(selectId, filterId);
+        return;
+      }
+      const handleFilter=()=>{ filterSelectOptionsByTerm(select, filter.value || ''); };
+      ['input','change'].forEach(evt=>{ filter.addEventListener(evt, handleFilter); });
+      filter.addEventListener('focus', handleFilter);
+      select.addEventListener('change', handleFilter);
+      filter.dataset.searchAttached='1';
+      handleFilter();
+    }
+
+
     function applyCaseManagerOptions(list, options){
       const select=document.getElementById('caseManagerName');
       if(!select) return;
@@ -8708,6 +8910,7 @@
       buildApprovalPlanPreview();
       scheduleSummaryUpdate();
       updateBasicInfoCompletion({ silent:true });
+      refreshSearchableSelect('caseManagerName','caseManagerFilter');
     }
 
     function loadManagers(){
@@ -8798,6 +9001,7 @@
       updateConsultVisitText();
       toggleCallDateByConsultVisit();
       scheduleSummaryUpdate();
+      refreshSearchableSelect('consultName','consultFilter');
       updateBasicInfoCompletion({ silent:true });
     }
 
@@ -17070,6 +17274,24 @@
       updateWizardButtons();
       syncPageWithWizardStep(targetStep);
       syncTabStatuses();
+      const currentMeta = wizardStepLookup[targetStep];
+      const currentLabelElement = document.getElementById('wizardCurrentStepLabel');
+      if(currentLabelElement){
+        if(currentMeta){
+          const labelText = currentMeta.label || (currentMeta.element?.querySelector('.wizard-label')?.textContent || '').trim();
+          currentLabelElement.textContent = labelText
+            ? `步驟 ${currentMeta.step}：${labelText}`
+            : `步驟 ${currentMeta.step}`;
+        }else{
+          currentLabelElement.textContent = wizardStepsMeta.length
+            ? `步驟 ${targetStep}`
+            : '—';
+        }
+      }
+      const currentMetaElement = document.getElementById('wizardCurrentStepMeta');
+      if(currentMetaElement){
+        currentMetaElement.textContent = wizardStepsMeta.length ? `共 ${wizardStepsMeta.length} 步` : '';
+      }
       const jumpSelect=getWizardJumpSelect();
       if(jumpSelect){ jumpSelect.value=''; }
     }
@@ -17290,6 +17512,26 @@
       return resolveWizardStepForElement(el);
     }
 
+    function syncWizardAnchoredHeadings(){
+      if(!wizardStepsMeta.length) return;
+      const seenPages={};
+      wizardStepsMeta.forEach(meta=>{
+        if(!meta) return;
+        const pageId=meta.page || '';
+        if(!pageId || seenPages[pageId]) return;
+        const heading=document.querySelector(`.page-section[data-page="${pageId}"] .group-header .h1`);
+        if(heading){
+          const original=(heading.dataset && heading.dataset.originalLabel) || (heading.textContent || '').trim();
+          if(!heading.dataset.originalLabel){
+            heading.dataset.originalLabel = original;
+          }
+          const label=meta.label || original;
+          heading.textContent = `步驟 ${meta.step}：${label}`;
+        }
+        seenPages[pageId]=true;
+      });
+    }
+
     function initWizardFlow(){
       wizardStepsMeta = [];
       wizardStepLookup = {};
@@ -17321,6 +17563,7 @@
         if(labelText){
           btn.setAttribute('title', `跳至${labelText}`);
         }
+        meta.label = labelText;
         meta.anchorElement = meta.anchor ? document.querySelector(meta.anchor) : null;
         wizardStepsMeta.push(meta);
         wizardStepLookup[step] = meta;
@@ -17334,6 +17577,7 @@
         btn.addEventListener('keydown', handleWizardStepKeydown);
       });
       wizardStepsMeta.sort(function(a,b){ return a.step - b.step; });
+      syncWizardAnchoredHeadings();
       if(wizardStepsMeta.length){
         const activeSection = document.querySelector('.page-section[data-active="1"]');
         let initialStep = null;
@@ -18160,7 +18404,16 @@
     }
 
     function initEventBindings(){
-      bindElement('#unitCode','change', ()=>{ loadManagers(); loadConsultants(); });
+      bindElement('#unitCode','change', ()=>{
+        loadManagers();
+        loadConsultants();
+        const managerFilter=document.getElementById('caseManagerFilter');
+        const consultFilter=document.getElementById('consultFilter');
+        if(managerFilter){ managerFilter.value=''; }
+        if(consultFilter){ consultFilter.value=''; }
+        refreshSearchableSelect('caseManagerName','caseManagerFilter');
+        refreshSearchableSelect('consultName','consultFilter');
+      });
       bindElement('#isConsultVisit','change', toggleCallDateByConsultVisit);
       bindElement('#consultName','change', ()=>{
         updateConsultVisitText();
@@ -18275,6 +18528,8 @@
       setDateBox('visitDate', new Date());
       loadManagers();
       loadConsultants();
+      setupSearchableSelect('caseManagerName','caseManagerFilter');
+      setupSearchableSelect('consultName','consultFilter');
       initCmsLevelButtons();
       loadServiceCatalog();
       initBasicInfoValidation();


### PR DESCRIPTION
## Summary
- redesign the sidebar header to pair the wizard with a progress card and clearer mobile layout
- add required indicators, contextual hints, and searchable filters to basic info selects
- tweak button hierarchy and spacing for better touch ergonomics across screen sizes
- reflow wizard steps into a responsive grid so the progress header no longer feels squeezed on desktop or mobile

## Testing
- not run (UI update)


------
https://chatgpt.com/codex/tasks/task_e_68dcd588d400832b8536d7e3a302b83b