### PR TITLE
Keep basic info selectors usable when rosters fail

### DIFF
--- a/src/Sidebar.html
+++ b/src/Sidebar.html
@@ -73,6 +73,7 @@
       --sticky-padding-inline:clamp(10px, 3.2vw, 18px);
       --wizard-index-size:34px;
       --wizard-index-font:0.95rem;
+      --wizard-gap:var(--space-sm);
       --group-header-spacing:var(--space-xs);
       --bottom-bar-min-height:48px;
       --layout-max:1440px;
@@ -107,7 +108,8 @@
 
       .wizard{
         overflow-x:auto;
-        gap:var(--space-xs);
+        --wizard-gap:var(--space-xs);
+        gap:var(--wizard-gap);
         padding-bottom:4px;
         scroll-snap-type:x proximity;
         -webkit-overflow-scrolling:touch;
@@ -1000,7 +1002,7 @@
       display:flex;
       justify-content:flex-start;
       align-items:center;
-      gap:var(--space-sm);
+      gap:var(--wizard-gap);
       flex-wrap:wrap;
     }
     .wizard-step{
@@ -1031,8 +1033,8 @@
       content:'';
       position:absolute;
       top:calc(var(--wizard-index-size) / 2);
-      left:-50%;
-      width:100%;
+      left:calc(-50% - var(--wizard-gap) / 2);
+      width:calc(100% + var(--wizard-gap));
       height:4px;
       background:#dbe5ff;
       z-index:-1;
@@ -1202,6 +1204,32 @@
       flex-direction:column;
       gap:var(--space-xs);
       min-width:0;
+    }
+    #basicInfoGroup .basic-info-field .basic-info-actions{
+      display:flex;
+      flex-wrap:wrap;
+      align-items:center;
+      gap:var(--space-xxs);
+      margin-top:calc(var(--space-xxs) / 2);
+    }
+    #basicInfoGroup .basic-info-field .basic-info-actions button{
+      appearance:none;
+      border:none;
+      background:none;
+      color:var(--accent);
+      font-size:0.85rem;
+      font-weight:600;
+      padding:0;
+      cursor:pointer;
+    }
+    #basicInfoGroup .basic-info-field .basic-info-actions button:hover,
+    #basicInfoGroup .basic-info-field .basic-info-actions button:focus-visible{
+      text-decoration:underline;
+    }
+    #basicInfoGroup .basic-info-field .basic-info-actions button:focus-visible{
+      outline:2px solid rgba(11,87,208,0.35);
+      outline-offset:2px;
+      border-radius:6px;
     }
     #basicInfoGroup .basic-info-field label{ margin-bottom:0; }
     #basicInfoGroup .unit-code-field{
@@ -2937,6 +2965,10 @@
                   <select id="caseManagerName">
                     <option value="" class="placeholder-option" disabled selected>請選擇</option>
                   </select>
+                  <div class="basic-info-actions" data-select-support="caseManagerName">
+                    <button type="button" data-action="reload-case-managers">重新載入</button>
+                    <button type="button" data-action="manual-case-manager">手動輸入</button>
+                  </div>
                   <div class="basic-info-status" id="caseManagerStatus" role="status" aria-live="polite"></div>
                 </div>
               </div>
@@ -2951,6 +2983,10 @@
                   <select id="consultName">
                     <option value="" class="placeholder-option" disabled selected>請選擇</option>
                   </select>
+                  <div class="basic-info-actions" data-select-support="consultName">
+                    <button type="button" data-action="reload-consultants">重新載入</button>
+                    <button type="button" data-action="manual-consult">手動輸入</button>
+                  </div>
                   <div class="basic-info-status" id="consultStatus" role="status" aria-live="polite"></div>
                 </div>
               </div>
@@ -4624,6 +4660,20 @@
     const HEADING_DOM_REGISTRY = {};
     let HEADING_INDEX_ORDER = 0;
 
+    const SIDE_NAV_MEDIA_QUERY = '(max-width: 1279px)';
+    const SIDE_NAV_TOGGLE_STATE = { button:null, backdrop:null, media:null, expanded:false };
+    const SIDE_NAV_STATE = (function(){
+      const fallback = { root:null, accordion:null, items:[], sections:{} };
+      if(typeof window === 'undefined'){
+        return fallback;
+      }
+      if(window.SIDE_NAV_STATE && typeof window.SIDE_NAV_STATE === 'object'){
+        return window.SIDE_NAV_STATE;
+      }
+      window.SIDE_NAV_STATE = fallback;
+      return window.SIDE_NAV_STATE;
+    })();
+
     const VALID_HEADING_TAGS = ['h1','h2','h3','h4','h5','h6'];
 
     function normalizeHeadingTag(tag, parent){
@@ -4769,9 +4819,6 @@
     function getHeadingGroup(anchorId){
       return anchorId ? headingGroupRegistry[anchorId] || null : null;
     }
-
-    const SIDE_NAV_MEDIA_QUERY = '(max-width: 1279px)';
-    const SIDE_NAV_TOGGLE_STATE = { button:null, backdrop:null, media:null, expanded:false };
 
     function getSideNavToggleElements(){
       if(!SIDE_NAV_TOGGLE_STATE.button){
@@ -6076,12 +6123,6 @@
     let globalBannerElements = null;
     let lastSavedTimestamp = null;
 
-    const SIDE_NAV_STATE = {
-      root:null,
-      accordion:null,
-      items:[],
-      sections:{}
-    };
     const Scheduler = (function(){
       let rafId = 0;
       const queues = {
@@ -8654,6 +8695,102 @@
       return 0;
     }
 
+    function setBasicInfoStatusMessage(statusId, message, state){
+      const statusEl=document.getElementById(statusId);
+      if(!statusEl) return;
+      if(typeof state === 'string' && state){
+        statusEl.dataset.state = state;
+      }else{
+        delete statusEl.dataset.state;
+        statusEl.removeAttribute('data-state');
+      }
+      if(typeof message === 'string'){
+        const text=message.trim();
+        if(text){
+          statusEl.dataset.customText = text;
+          statusEl.textContent = text;
+        }else{
+          delete statusEl.dataset.customText;
+          statusEl.removeAttribute('data-custom-text');
+          statusEl.textContent='';
+        }
+      }
+    }
+
+    function applyBasicInfoFieldLoadState(fieldId, state){
+      const field=document.getElementById(fieldId);
+      if(!field) return;
+      const container=field.closest('.basic-info-field');
+      if(!container) return;
+      if(typeof state === 'string' && state){
+        container.dataset.loadState = state;
+      }else{
+        container.removeAttribute('data-load-state');
+      }
+    }
+
+    function getManualSelectValues(select){
+      if(!select) return [];
+      const values=[];
+      const seen=new Set();
+      Array.prototype.forEach.call(select.options, option=>{
+        if(!option || !option.dataset || option.dataset.manual !== '1') return;
+        const text=(option.value || '').trim();
+        if(!text || seen.has(text)) return;
+        seen.add(text);
+        values.push(text);
+      });
+      return values;
+    }
+
+    function ensureManualSelectOption(select, value){
+      if(!select) return null;
+      const text=typeof value === 'string' ? value.trim() : '';
+      if(!text) return null;
+      let option=null;
+      Array.prototype.forEach.call(select.options, current=>{
+        if(option) return;
+        if(!current) return;
+        if((current.value || '').trim() === text){
+          option=current;
+        }
+      });
+      if(!option){
+        option=document.createElement('option');
+        option.value=text;
+        option.textContent=text;
+        select.appendChild(option);
+      }
+      option.dataset.manual='1';
+      option.disabled=false;
+      option.classList.remove('placeholder-option');
+      return option;
+    }
+
+    function promptManualSelectValue(fieldId, statusId, label){
+      const select=document.getElementById(fieldId);
+      if(!select) return;
+      const current=(select.value || '').trim();
+      const promptLabel=label ? String(label).trim() : '';
+      const message=promptLabel ? `請輸入${promptLabel}` : '請輸入內容';
+      const input=window.prompt(`${message}：`, current);
+      if(input === null) return;
+      const text=String(input).trim();
+      if(!text){
+        return;
+      }
+      const option=ensureManualSelectOption(select, text);
+      if(option){
+        select.disabled=false;
+        select.value=text;
+        setBasicInfoStatusMessage(statusId, '', null);
+        applyBasicInfoFieldLoadState(fieldId, '');
+        const changeEvent=new Event('change', { bubbles:true });
+        select.dispatchEvent(changeEvent);
+        updateBasicInfoCompletion();
+      }
+    }
+
 
     function applyCaseManagerOptions(list, options){
       const select=document.getElementById('caseManagerName');
@@ -8661,6 +8798,8 @@
       const previousValue=options && typeof options.previousValue === 'string'
         ? options.previousValue.trim()
         : (select.value || '').trim();
+      const manualEntries=getManualSelectValues(select);
+      const manualSet=new Set(manualEntries);
       const hasData=Array.isArray(list) && list.length > 0;
       const placeholderText=(options && options.placeholder)
         ? options.placeholder
@@ -8674,37 +8813,47 @@
       placeholder.selected=true;
       select.appendChild(placeholder);
       let matched=false;
+      const existingValues=new Set();
+      const appendOption=(value, isManual)=>{
+        const text=typeof value === 'string' ? value.trim() : '';
+        if(!text || existingValues.has(text)) return;
+        const option=document.createElement('option');
+        option.value=text;
+        option.textContent=text;
+        if(isManual){
+          option.dataset.manual='1';
+        }
+        if(text === previousValue){
+          option.selected=true;
+          matched=true;
+        }
+        select.appendChild(option);
+        existingValues.add(text);
+      };
       if(hasData){
         list.forEach(name=>{
           const text=String(name || '').trim();
           if(!text) return;
-          const option=document.createElement('option');
-          option.value=text;
-          option.textContent=text;
-          if(text === previousValue){
-            option.selected=true;
-            matched=true;
-          }
-          select.appendChild(option);
+          appendOption(text, manualSet.has(text));
         });
-        select.disabled=false;
-      }else if(options && options.fallbackValue){
+      }
+      if(!hasData && options && options.fallbackValue){
         const preserved=String(options.fallbackValue).trim();
         if(preserved){
-          const option=document.createElement('option');
-          option.value=preserved;
-          option.textContent=preserved;
-          option.selected=true;
-          select.appendChild(option);
-          matched=true;
-          select.disabled=false;
+          appendOption(preserved, manualSet.has(preserved));
         }
-      }else{
-        select.disabled=!(options && options.keepEnabled);
       }
+      manualEntries.forEach(text=>{
+        appendOption(text, true);
+      });
       if(!matched){
         select.selectedIndex=0;
       }
+      let shouldEnable=hasData || manualEntries.length > 0 || (options && options.keepEnabled);
+      if(!shouldEnable && select.options.length > 1){
+        shouldEnable=true;
+      }
+      select.disabled=!shouldEnable;
       buildApprovalPlanPreview();
       scheduleSummaryUpdate();
       updateBasicInfoCompletion({ silent:true });
@@ -8713,19 +8862,29 @@
     function loadManagers(){
       const select=document.getElementById('caseManagerName');
       if(!select) return;
-      const unit=document.getElementById('unitCode').value;
+      const unit=document.getElementById('unitCode')?.value || '';
       const previousValue=(select.value || '').trim();
+      setBasicInfoStatusMessage('caseManagerStatus','正在載入個案管理師名單…','invalid');
+      applyBasicInfoFieldLoadState('caseManagerName','loading');
       const handleFailure=()=>{
         applyCaseManagerOptions([], {
           previousValue,
           fallbackValue: previousValue,
-          placeholder:'（載入失敗）'
+          placeholder:'（載入失敗，請手動輸入或重新嘗試）',
+          allowPlaceholderSelection:true,
+          keepEnabled:true
         });
+        applyBasicInfoFieldLoadState('caseManagerName','error');
+        setBasicInfoStatusMessage('caseManagerStatus','無法載入名單，請手動輸入或點「重新載入」。','invalid');
+        updateBasicInfoCompletion({ silent:true });
       };
       const attemptFetch=runner=>{
         try{
           runner.withSuccessHandler(list=>{
             applyCaseManagerOptions(Array.isArray(list) ? list : [], { previousValue });
+            applyBasicInfoFieldLoadState('caseManagerName','');
+            setBasicInfoStatusMessage('caseManagerStatus','', null);
+            updateBasicInfoCompletion({ silent:true });
           }).withFailureHandler(()=>{ handleFailure(); }).getCaseManagersByUnit(unit);
         }catch(err){
           handleFailure();
@@ -8739,7 +8898,9 @@
       if(status === 0){
         applyCaseManagerOptions([], {
           previousValue,
-          placeholder:'（載入中…）'
+          placeholder:'（載入中…）',
+          allowPlaceholderSelection:true,
+          keepEnabled:true
         });
       }
     }
@@ -8751,6 +8912,8 @@
       const previousValue=options && typeof options.previousValue === 'string'
         ? options.previousValue.trim()
         : (select.value || '').trim();
+      const manualEntries=getManualSelectValues(select);
+      const manualSet=new Set(manualEntries);
       const hasData=Array.isArray(list) && list.length > 0;
       const placeholderText=(options && options.placeholder)
         ? options.placeholder
@@ -8764,37 +8927,47 @@
       placeholder.selected=true;
       select.appendChild(placeholder);
       let matched=false;
+      const existingValues=new Set();
+      const appendOption=(value, isManual)=>{
+        const text=typeof value === 'string' ? value.trim() : '';
+        if(!text || existingValues.has(text)) return;
+        const option=document.createElement('option');
+        option.value=text;
+        option.textContent=text;
+        if(isManual){
+          option.dataset.manual='1';
+        }
+        if(text === previousValue){
+          option.selected=true;
+          matched=true;
+        }
+        select.appendChild(option);
+        existingValues.add(text);
+      };
       if(hasData){
         list.forEach(name=>{
           const text=String(name || '').trim();
           if(!text) return;
-          const option=document.createElement('option');
-          option.value=text;
-          option.textContent=text;
-          if(text === previousValue){
-            option.selected=true;
-            matched=true;
-          }
-          select.appendChild(option);
+          appendOption(text, manualSet.has(text));
         });
-        select.disabled=false;
-      }else if(options && options.fallbackValue){
+      }
+      if(!hasData && options && options.fallbackValue){
         const preserved=String(options.fallbackValue).trim();
         if(preserved){
-          const option=document.createElement('option');
-          option.value=preserved;
-          option.textContent=preserved;
-          option.selected=true;
-          select.appendChild(option);
-          matched=true;
-          select.disabled=false;
+          appendOption(preserved, manualSet.has(preserved));
         }
-      }else{
-        select.disabled=!(options && options.keepEnabled);
       }
+      manualEntries.forEach(text=>{
+        appendOption(text, true);
+      });
       if(!matched){
         select.selectedIndex=0;
       }
+      let shouldEnable=hasData || manualEntries.length > 0 || (options && options.keepEnabled);
+      if(!shouldEnable && select.options.length > 1){
+        shouldEnable=true;
+      }
+      select.disabled=!shouldEnable;
       updateConsultVisitText();
       toggleCallDateByConsultVisit();
       scheduleSummaryUpdate();
@@ -8804,19 +8977,29 @@
     function loadConsultants(){
       const select=document.getElementById('consultName');
       if(!select) return;
-      const unit=document.getElementById('unitCode').value;
+      const unit=document.getElementById('unitCode')?.value || '';
       const previousValue=(select.value || '').trim();
+      setBasicInfoStatusMessage('consultStatus','正在載入照專名單…','invalid');
+      applyBasicInfoFieldLoadState('consultName','loading');
       const handleFailure=()=>{
         applyConsultantOptions([], {
           previousValue,
           fallbackValue: previousValue,
-          placeholder:'（載入失敗）'
+          placeholder:'（載入失敗，請手動輸入或重新嘗試）',
+          allowPlaceholderSelection:true,
+          keepEnabled:true
         });
+        applyBasicInfoFieldLoadState('consultName','error');
+        setBasicInfoStatusMessage('consultStatus','無法載入名單，請手動輸入或點「重新載入」。','invalid');
+        updateBasicInfoCompletion({ silent:true });
       };
       const attemptFetch=runner=>{
         try{
           runner.withSuccessHandler(list=>{
             applyConsultantOptions(Array.isArray(list) ? list : [], { previousValue });
+            applyBasicInfoFieldLoadState('consultName','');
+            setBasicInfoStatusMessage('consultStatus','', null);
+            updateBasicInfoCompletion({ silent:true });
           }).withFailureHandler(()=>{ handleFailure(); }).getConsultantsByUnit(unit);
         }catch(err){
           handleFailure();
@@ -8830,7 +9013,9 @@
       if(status === 0){
         applyConsultantOptions([], {
           previousValue,
-          placeholder:'（載入中…）'
+          placeholder:'（載入中…）',
+          allowPlaceholderSelection:true,
+          keepEnabled:true
         });
       }
     }
@@ -17815,7 +18000,12 @@
       if(statusEl){
         statusEl.dataset.state = status;
         const label=field.label || '';
-        if(filled){
+        const override=statusEl.dataset && typeof statusEl.dataset.customText === 'string'
+          ? statusEl.dataset.customText
+          : '';
+        if(override){
+          statusEl.textContent = override;
+        }else if(filled){
           statusEl.textContent = label ? `「${label}」已完成` : '已完成';
         }else{
           statusEl.textContent = label ? `請完成「${label}」` : '請完成此欄位';
@@ -18226,6 +18416,10 @@
       bindAction('reset-respite-phrases', resetRespitePhrases);
       bindAction('reset-meal-phrases', resetMealPhrases);
       bindAction('apply-and-save', applyAndSave);
+      bindAction('reload-case-managers', ()=>{ loadManagers(); });
+      bindAction('manual-case-manager', ()=>{ promptManualSelectValue('caseManagerName','caseManagerStatus','個案管理師姓名'); });
+      bindAction('reload-consultants', ()=>{ loadConsultants(); });
+      bindAction('manual-consult', ()=>{ promptManualSelectValue('consultName','consultStatus','照專姓名'); });
     }
 
     function applyEllipsisTooltips(){


### PR DESCRIPTION
## Summary
- initialise the shared side navigation state before building the heading index so sidebar setup no longer throws in standalone testing environments
- update the basic info status helper to clear stale state and keep the roster selects enabled with fallback placeholders when Google runner calls fail

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcf6fdde98832bb832d5354e130f79