### PR TITLE
chore: align Playwright runtime setup

### DIFF
--- a/.github/workflows/gas-deploy.yml
+++ b/.github/workflows/gas-deploy.yml
@@ -33,6 +33,7 @@ jobs:
       - name: "Install deps"
         run: |
           if [ -f package-lock.json ]; then npm ci; else npm install; fi
+          npx playwright install --with-deps
 
       - name: "Run unit tests (Jest)"
         run: npm test --if-present
@@ -55,6 +56,7 @@ jobs:
       - name: "Install deps"
         run: |
           if [ -f package-lock.json ]; then npm ci; else npm install; fi
+          npx playwright install --with-deps
 
       - name: "Install latest clasp"
         run: npm i -g @google/clasp

--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -17,7 +17,7 @@ jobs:
     name: Run predeploy suite
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.55.0-jammy
+      image: mcr.microsoft.com/playwright:v1.55.1-jammy
     env:
       GAS_WEBAPP_URL: ${{ secrets.GAS_WEBAPP_URL }}
     steps:
@@ -32,6 +32,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
 
       - name: Run predeploy checks
         run: npm run predeploy

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@eslint/eslintrc": "^3.1.0",
         "@eslint/js": "^9.14.0",
         "@google/clasp": "^2.5.0",
-        "@playwright/test": "^1.48.2",
+        "@playwright/test": "1.55.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@types/jest": "^29.5.13",
         "@types/node": "^22.9.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.14.0",
     "@google/clasp": "^2.5.0",
-    "@playwright/test": "^1.48.2",
+    "@playwright/test": "1.55.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@types/jest": "^29.5.13",
     "@types/node": "^22.9.3",


### PR DESCRIPTION
## Summary
- pin `@playwright/test` to 1.55.1 so lockfile matches dependency expectations
- update CI workflows to install Playwright browsers after dependency install and upgrade the Playwright container image

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`
- `npm run predeploy` *(fails: pa11y requires --no-sandbox when running as root in this environment)*
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68dd8eb1ba80832bb21da5010af84da9