### PR TITLE
test: expand remote sidebar navigation check

### DIFF
--- a/playwright/remote.spec.ts
+++ b/playwright/remote.spec.ts
@@ -19,7 +19,13 @@ test.describe('@remote GAS sidebar smoke checks', () => {
 
   test('@remote sidebar renders navigation for authenticated session', async ({ page }) => {
     await openPage(page);
-    await expect(page).toHaveTitle(/AA01/);
-    await expect(page.locator('#sideNavToggleButton')).toBeVisible();
+    const toggleButton = page.locator('#sideNavToggleButton');
+    const sideNav = page.locator('nav#sideNav');
+
+    await expect(toggleButton).toBeVisible();
+    await expect(sideNav).toBeHidden({ timeout: 0 });
+
+    await toggleButton.click();
+    await expect(sideNav).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- adjust the remote sidebar smoke test to focus on the side navigation toggle instead of the document title
- verify the drawer is hidden by default, becomes visible after clicking the toggle button, and keep existing helper usage unchanged

## Testing
- npm run lint
- CI=1 npm run test
- npm run e2e

------
https://chatgpt.com/codex/tasks/task_e_68dea9995100832bbc14ca3635236cff