### PR TITLE
ci: add preview deployment workflow and update e2e helpers

### DIFF
--- a/.github/workflows/ci-preview.yml
+++ b/.github/workflows/ci-preview.yml
@@ -1,0 +1,83 @@
+name: ci-preview
+on:
+  push:
+    branches-ignore: [ main ]
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:v1.55.1-jammy
+    concurrency:
+      group: preview-${{ github.ref }}
+      cancel-in-progress: true
+    env:
+      HAS_AUTH: ${{ secrets.PLAYWRIGHT_AUTH_STATE != '' }}
+      TEST_DEPLOYMENT_ID: ${{ secrets.TEST_DEPLOYMENT_ID }}
+      E2E_PATH: ${{ vars.E2E_PATH }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: npm }
+      - run: npm ci
+
+      - name: Setup clasp credentials
+        run: |
+          echo '${{ secrets.CLASP_CREDENTIALS }}' > ~/.clasprc.json
+          echo "✔ wrote ~/.clasprc.json"
+
+      - name: Create GAS version
+        id: ver
+        run: |
+          set -e
+          npx clasp version "ci:${GITHUB_SHA::7}" || true
+          VER=$(npx clasp versions | awk '/^@/ {v=$2} END{print v}')
+          [ -n "$VER" ] || (echo "No version found"; exit 1)
+          echo "ver=$VER" >> $GITHUB_OUTPUT
+          echo "Created version $VER"
+
+      - name: Update TEST deployment (staging/preview)
+        run: npx clasp deploy -i "$TEST_DEPLOYMENT_ID" -V "${{ steps.ver.outputs.ver }}"
+
+      - name: Export STAGING url
+        id: url
+        run: echo "url=https://script.google.com/macros/s/${TEST_DEPLOYMENT_ID}/exec" >> $GITHUB_OUTPUT
+
+      - name: Run local E2E (@ui)
+        run: npm run e2e:ui
+
+      - name: Restore auth.json
+        if: ${{ env.HAS_AUTH == 'true' }}
+        run: echo "${{ secrets.PLAYWRIGHT_AUTH_STATE }}" | base64 -d > auth.json
+
+      - name: Run remote E2E (@remote → staging)
+        if: ${{ env.HAS_AUTH == 'true' }}
+        run: npm run e2e:remote
+        env:
+          GAS_WEBAPP_URL: ${{ steps.url.outputs.url }}
+          E2E_PATH: ${{ env.E2E_PATH }}
+
+      - name: Health (200/302 or skip)
+        run: npm run health
+        env:
+          GAS_WEBAPP_URL: ${{ steps.url.outputs.url }}
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report
+          if-no-files-found: ignore
+
+      - name: Comment to PR (if exists)
+        if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          header: staging-preview
+          message: |
+            **Staging preview** for `${{ github.ref }}`:
+            ${{ steps.url.outputs.url }}${{ env.E2E_PATH || '' }}

--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -21,6 +21,7 @@ jobs:
       HAS_AUTH: ${{ secrets.PLAYWRIGHT_AUTH_STATE != '' }}
       HAS_URL: ${{ secrets.GAS_WEBAPP_URL != '' }}
       GAS_WEBAPP_URL: ${{ secrets.GAS_WEBAPP_URL }}
+      E2E_PATH: ${{ vars.E2E_PATH }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -31,6 +32,24 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Setup clasp credentials
+        run: |
+          echo '${{ secrets.CLASP_CREDENTIALS }}' > ~/.clasprc.json
+          echo "✔ wrote ~/.clasprc.json"
+
+      - name: Create GAS version (prod)
+        id: ver_prod
+        run: |
+          set -e
+          npx clasp version "prod:${GITHUB_SHA::7}" || true
+          VER=$(npx clasp versions | awk '/^@/ {v=$2} END{print v}')
+          [ -n "$VER" ] || (echo "No version found"; exit 1)
+          echo "ver=$VER" >> $GITHUB_OUTPUT
+          echo "Created version $VER"
+
+      - name: Update PROD deployment
+        run: npx clasp deploy -i "${{ secrets.GAS_DEPLOYMENT_ID }}" -V "${{ steps.ver_prod.outputs.ver }}"
 
       - name: Restore auth (and debug)
         if: ${{ env.HAS_AUTH == 'true' }}
@@ -49,6 +68,7 @@ jobs:
         run: npm run e2e:remote
         env:
           GAS_WEBAPP_URL: ${{ env.GAS_WEBAPP_URL }}
+          E2E_PATH: ${{ env.E2E_PATH }}
 
       - name: Health check (200/302 or skip)
         run: npm run health

--- a/playwright/utils/openPage.ts
+++ b/playwright/utils/openPage.ts
@@ -3,20 +3,40 @@ import type { Page } from '@playwright/test';
 
 const localHtml = 'file://' + path.resolve('src/Sidebar.html');
 
+function joinUrl(base: string, extra?: string) {
+  if (!extra) return base;
+  if (/^[?#]/.test(extra)) return base + extra;
+  if (extra.startsWith('/')) return base.replace(/\/+$/, '') + extra;
+  return base.replace(/\/+$/, '') + '/' + extra.replace(/^\/+/, '');
+}
+
 export function isRemoteTarget(): boolean {
   return process.env.E2E_TARGET === 'remote' && Boolean(process.env.GAS_WEBAPP_URL);
 }
 
 export async function openPage(page: Page, width = 1280, height = 960) {
   await page.setViewportSize({ width, height });
-  const target = isRemoteTarget() ? (process.env.GAS_WEBAPP_URL as string) : localHtml;
+  const base = process.env.GAS_WEBAPP_URL || '';
+  const extra = process.env.E2E_PATH || '';
+  const target = isRemoteTarget() ? joinUrl(base, extra) : localHtml;
   await page.goto(target, { waitUntil: 'domcontentloaded' });
-  await page.waitForLoadState('load');
+  // eslint-disable-next-line playwright/no-networkidle
+  await page.waitForLoadState('networkidle');
 
   if (isRemoteTarget()) {
     const currentUrl = page.url();
     if (/accounts\.google\.com/i.test(currentUrl)) {
       throw new Error('登入態過期，請重新產生 auth.json 後重試');
     }
+    const nav = page.locator('[data-testid=side-nav]');
+    const navToggle = page.locator('[data-testid=side-nav-toggle]');
+    const basicInfoGroup = page.locator('#basicInfoGroup');
+    const basicInfoText = page.getByText('基本資訊');
+    await Promise.race([
+      nav.first().waitFor({ state: 'visible', timeout: 10000 }),
+      navToggle.first().waitFor({ state: 'visible', timeout: 10000 }),
+      basicInfoGroup.waitFor({ state: 'visible', timeout: 10000 }),
+      basicInfoText.first().waitFor({ state: 'visible', timeout: 10000 })
+    ]);
   }
 }


### PR DESCRIPTION
## Summary
- add ci-preview workflow that deploys the TEST Google Apps Script version and exercises local/remote E2E plus health checks
- extend predeploy to publish a prod version via GAS_DEPLOYMENT_ID and pass shared preview variables to remote runs
- enhance Playwright openPage helper to honor E2E_PATH, wait for network idle, and guard for key UI selectors

## Testing
- npm run lint
- npm run test
- npm run e2e
- npm run health

------
https://chatgpt.com/codex/tasks/task_e_68dee2583cb8832ba78e421e0d31f83f