### PR TITLE
feat: normalize remote e2e URLs

### DIFF
--- a/__tests__/unit/buildRemoteUrl.test.ts
+++ b/__tests__/unit/buildRemoteUrl.test.ts
@@ -1,0 +1,49 @@
+import { buildRemoteUrl } from '../../src/utils/buildRemoteUrl.js';
+
+describe('buildRemoteUrl', () => {
+  const BASE = 'https://host/exec';
+  const BASE_WITH_QUERY = 'https://host/exec?baseline=1';
+  const LOCAL = 'http://127.0.0.1:3000';
+
+  it('returns the base URL when E2E_PATH is empty', () => {
+    const url = buildRemoteUrl(BASE, '');
+    expect(url.toString()).toBe('https://host/exec');
+  });
+
+  it('merges query parameters when path is only a query string', () => {
+    const url = buildRemoteUrl(BASE, '?foo=bar');
+    expect(url.pathname).toBe('/exec');
+    expect(url.searchParams.get('foo')).toBe('bar');
+  });
+
+  it('throws when base and path would create a duplicate /exec', () => {
+    expect(() => buildRemoteUrl(BASE, '/exec?x=1')).toThrow(/Duplicate \/exec/);
+  });
+
+  it('retains base query parameters and merges new ones', () => {
+    const url = buildRemoteUrl(BASE_WITH_QUERY, '?foo=bar');
+    expect(url.pathname).toBe('/exec');
+    expect(url.searchParams.get('baseline')).toBe('1');
+    expect(url.searchParams.get('foo')).toBe('bar');
+  });
+
+  it('normalizes general paths by ensuring a leading slash', () => {
+    const url = buildRemoteUrl('https://host', 'aa/bb');
+    expect(url.pathname).toBe('/aa/bb');
+    expect(url.toString()).toBe('https://host/aa/bb');
+  });
+
+  it('collapses extra slashes and resolves dot segments via URL semantics', () => {
+    const url = buildRemoteUrl('https://host/app/', '///aa///../bb');
+    expect(url.pathname).toBe('/app/bb');
+  });
+
+  it('throws when GAS_WEBAPP_URL is missing and fallback is disabled', () => {
+    expect(() => buildRemoteUrl(undefined, '/')).toThrow(/GAS_WEBAPP_URL is required/);
+  });
+
+  it('falls back to the local base when allowed', () => {
+    const url = buildRemoteUrl(undefined, '/', { allowLocalFallback: true, localBase: LOCAL });
+    expect(url.toString()).toBe(`${LOCAL}/`);
+  });
+});

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -8,6 +8,7 @@ module.exports = {
   testMatch: ['**/__tests__/**/*.test.(js|ts)'],
   setupFilesAfterEnv: [path.resolve(__dirname, 'test', 'setup-tests.ts')],
   collectCoverage: true,
+  coverageProvider: 'v8',
   transform: {
     '^.+\\.(ts|tsx)$': [
       'ts-jest',
@@ -16,6 +17,9 @@ module.exports = {
         tsconfig: path.resolve(__dirname, 'tsconfig.test.json')
       }
     ]
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
   },
   extensionsToTreatAsEsm: ['.ts'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'cjs', 'mjs', 'json'],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "lint": "eslint --max-warnings=0 --ext .js,.cjs,.mjs,.ts,.tsx __tests__ playwright scripts",
+    "lint": "eslint --max-warnings=0 --ext .js,.cjs,.mjs,.ts,.tsx src __tests__ playwright scripts",
     "format": "prettier --check .",
     "test": "jest --config=jest.config.cjs",
     "test:watch": "jest --watch --config=jest.config.cjs",

--- a/playwright/remote.spec.ts
+++ b/playwright/remote.spec.ts
@@ -18,6 +18,12 @@ test.describe('AA01 remote sidebar RWD smoke (@remote)', () => {
     await expect(page.getByTestId('side-nav').first()).toBeVisible();
   });
 
+  test('remote target URL is normalized', async ({ page }) => {
+    const { targetUrl, finalUrl } = await openPage(page);
+    expect(targetUrl).not.toMatch(/\/exec\/exec/i);
+    expect(finalUrl).not.toMatch(/\/exec\/exec/i);
+  });
+
   test('tablet (640–1279): toggle exists, nav opens/closes', async ({ page }) => {
     await openPage(page);
     await page.setViewportSize({ width: 1024, height: 900 });

--- a/src/utils/buildRemoteUrl.ts
+++ b/src/utils/buildRemoteUrl.ts
@@ -1,0 +1,97 @@
+export type BuildUrlOptions = {
+  allowLocalFallback?: boolean;
+  localBase?: string;
+};
+
+const EXEC_SEGMENT = '/exec';
+
+function stripTrailingSlash(value: string) {
+  return value.replace(/\/+$/u, '');
+}
+
+function ensureLeadingSlash(value: string) {
+  return value.startsWith('/') ? value : `/${value}`;
+}
+
+function isOnlyQuery(value: string) {
+  return Boolean(value) && value.startsWith('?');
+}
+
+function cloneUrl(url: URL) {
+  return new URL(url.toString());
+}
+
+export function buildRemoteUrl(
+  gasWebappUrl: string | undefined,
+  e2ePath: string | undefined,
+  options: BuildUrlOptions = {}
+): URL {
+  const { allowLocalFallback = false, localBase = 'http://127.0.0.1:3000' } = options;
+
+  const baseRaw = (gasWebappUrl ?? '').trim();
+  const pathRaw = (e2ePath ?? '').trim();
+
+  if (!baseRaw) {
+    if (allowLocalFallback) {
+      return buildRemoteUrl(localBase, pathRaw, {
+        allowLocalFallback: false,
+        localBase
+      });
+    }
+    throw new Error('GAS_WEBAPP_URL is required for remote E2E (missing or empty).');
+  }
+
+  const baseUrl = new URL(baseRaw);
+  const result = cloneUrl(baseUrl);
+
+  const basePathname = baseUrl.pathname || '/';
+  const normalizedBasePathname = basePathname === '' ? '/' : basePathname;
+
+  let normalizedPathname = '';
+  let queryFragment = '';
+
+  if (!pathRaw) {
+    normalizedPathname = '';
+  } else if (isOnlyQuery(pathRaw)) {
+    queryFragment = pathRaw.slice(1);
+  } else {
+    const [rawPathSegment, rawQuerySegment] = pathRaw.split('?');
+    normalizedPathname = ensureLeadingSlash(rawPathSegment).replace(/\/{2,}/g, '/');
+    queryFragment = rawQuerySegment ?? '';
+  }
+
+  const baseEndsWithExec = stripTrailingSlash(normalizedBasePathname).endsWith(EXEC_SEGMENT);
+  const pathStartsWithExec = normalizedPathname.startsWith(EXEC_SEGMENT);
+
+  if (normalizedPathname && baseEndsWithExec && pathStartsWithExec) {
+    throw new Error('Duplicate /exec detected between GAS_WEBAPP_URL and E2E_PATH.');
+  }
+
+  let finalPathname = normalizedBasePathname;
+
+  if (normalizedPathname) {
+    const basePrefix = stripTrailingSlash(normalizedBasePathname);
+    if (pathStartsWithExec) {
+      finalPathname = normalizedPathname;
+    } else if (basePrefix) {
+      finalPathname = `${basePrefix}${normalizedPathname}`;
+    } else {
+      finalPathname = normalizedPathname;
+    }
+  }
+
+  result.pathname = finalPathname || '/';
+
+  if (queryFragment) {
+    const params = new URLSearchParams(queryFragment);
+    for (const [key, value] of params.entries()) {
+      result.searchParams.set(key, value);
+    }
+  }
+
+  if (/\/exec\/exec(\/?|$)/i.test(result.pathname)) {
+    throw new Error('Duplicate /exec detected in final URL.');
+  }
+
+  return result;
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -10,6 +10,6 @@
     "noEmit": true,
     "skipLibCheck": true
   },
-  "include": ["__tests__/**/*", "test/**/*", "playwright/**/*"],
+  "include": ["__tests__/**/*", "test/**/*", "playwright/**/*", "src/utils/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- add a shared URL builder that normalizes GAS webapp URLs and guards duplicate /exec segments
- update Playwright openPage helper to log final URLs, reuse the builder, and expand remote smoke coverage
- extend Jest configuration and scripts so the helper is linted/tested with new unit coverage

## Testing
- npm run lint
- npm run test
- npm run e2e *(fails: Playwright browsers not installed in runner)*

------
https://chatgpt.com/codex/tasks/task_e_68df6504c928832b87cfcb776bcaab60