### PR TITLE
fix: harden clasp setup across workflows

### DIFF
--- a/.github/workflows/ci-preview.yml
+++ b/.github/workflows/ci-preview.yml
@@ -14,6 +14,10 @@ permissions:
   pull-requests: write
   issues: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   preview:
     runs-on: ubuntu-latest
@@ -37,25 +41,31 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: 20, cache: npm }
-      - run: npm ci
+      - name: Install dependencies
+        run: npm ci
+        env:
+          HUSKY: '0'
 
       - name: Write ~/.clasprc.json
         env:
           CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
         run: |
+          bash -eo pipefail <<'BASH'
           set -euo pipefail
-          [ -n "${CLASPRC_JSON:-}" ] || { echo "::error::Missing CLASPRC_JSON"; exit 1; }
+          : "${CLASPRC_JSON:?Missing CLASPRC_JSON}"
           node -e "
-            const fs=require('fs');const p=process.env.HOME+'/.clasprc.json';
-            let s=process.env.CLASPRC_JSON||'';let j;
-            try{ j=JSON.parse(s); }
-            catch(e){ s=s.replace(/\s+/g,''); j=JSON.parse(Buffer.from(s,'base64').toString()); }
-            if(!j.token && j.tokens && j.tokens.default){ j.token=j.tokens.default; }
-            fs.mkdirSync(require('path').dirname(p),{recursive:true});
+            const fs=require('fs'), path=require('path');
+            const p=process.env.HOME+'/.clasprc.json';
+            let s=process.env.CLASPRC_JSON||''; let j;
+            try { j=JSON.parse(s); }
+            catch (e) { s=s.replace(/\s+/g,''); j=JSON.parse(Buffer.from(s,'base64').toString()); }
+            if(!j.token && j.tokens?.default) j.token=j.tokens.default;
+            fs.mkdirSync(path.dirname(p), {recursive:true});
             fs.writeFileSync(p, JSON.stringify(j,null,2));
           "
           test -s "$HOME/.clasprc.json"
           cp "$HOME/.clasprc.json" "$GITHUB_WORKSPACE/.clasprc.json"
+          BASH
 
       - name: Create GAS version
         id: ver

--- a/.github/workflows/gas-deploy.yml
+++ b/.github/workflows/gas-deploy.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: "Install dependencies"
         run: npm ci
+        env:
+          HUSKY: '0'
 
       - name: "Cache Playwright browsers"
         uses: actions/cache@v4
@@ -75,6 +77,8 @@ jobs:
 
       - name: "Install dependencies"
         run: npm ci
+        env:
+          HUSKY: '0'
 
       - name: "Cache Playwright browsers"
         uses: actions/cache@v4
@@ -163,21 +167,22 @@ jobs:
         env:
           CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
         run: |
+          bash -eo pipefail <<'BASH'
           set -euo pipefail
-          [ -n "${CLASPRC_JSON:-}" ] || { echo "::error::Missing CLASPRC_JSON"; exit 1; }
+          : "${CLASPRC_JSON:?Missing CLASPRC_JSON}"
           node -e "
-            const fs=require('fs');const path=require('path');
-            const target=path.join(process.env.HOME||require('os').homedir(),'.clasprc.json');
+            const fs=require('fs'), path=require('path');
+            const p=process.env.HOME+'/.clasprc.json';
             let s=process.env.CLASPRC_JSON||''; let j;
             try { j=JSON.parse(s); }
-            catch(e) { s=s.replace(/\s+/g,''); j=JSON.parse(Buffer.from(s,'base64').toString()); }
-            if(!j.token && j.tokens && j.tokens.default){ j.token=j.tokens.default; }
-            fs.mkdirSync(path.dirname(target),{recursive:true});
-            fs.writeFileSync(target,JSON.stringify(j,null,2));
+            catch (e) { s=s.replace(/\s+/g,''); j=JSON.parse(Buffer.from(s,'base64').toString()); }
+            if(!j.token && j.tokens?.default) j.token=j.tokens.default;
+            fs.mkdirSync(path.dirname(p), {recursive:true});
+            fs.writeFileSync(p, JSON.stringify(j,null,2));
           "
           test -s "$HOME/.clasprc.json"
           cp "$HOME/.clasprc.json" "$GITHUB_WORKSPACE/.clasprc.json"
-        shell: bash
+          BASH
 
       - name: "Preflight: check TEST secrets & clasp & script"
         run: |
@@ -510,17 +515,22 @@ jobs:
         env:
           CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
         run: |
+          bash -eo pipefail <<'BASH'
           set -euo pipefail
-          [ -n "${CLASPRC_JSON:-}" ] || { echo "::error::Missing CLASPRC_JSON"; exit 1; }
+          : "${CLASPRC_JSON:?Missing CLASPRC_JSON}"
           node -e "
-            const fs=require('fs');const p=process.env.HOME+'/.clasprc.json';
-            let s=process.env.CLASPRC_JSON||'';let j;
-            try{ j=JSON.parse(s); }catch(e){ s=s.replace(/\s+/g,''); j=JSON.parse(Buffer.from(s,'base64').toString()); }
-            if(!j.token && j.tokens && j.tokens.default){ j.token=j.tokens.default; }
+            const fs=require('fs'), path=require('path');
+            const p=process.env.HOME+'/.clasprc.json';
+            let s=process.env.CLASPRC_JSON||''; let j;
+            try { j=JSON.parse(s); }
+            catch (e) { s=s.replace(/\s+/g,''); j=JSON.parse(Buffer.from(s,'base64').toString()); }
+            if(!j.token && j.tokens?.default) j.token=j.tokens.default;
+            fs.mkdirSync(path.dirname(p), {recursive:true});
             fs.writeFileSync(p, JSON.stringify(j,null,2));
           "
           test -s "$HOME/.clasprc.json"
           cp "$HOME/.clasprc.json" "$GITHUB_WORKSPACE/.clasprc.json"
+          BASH
 
       - name: "Snapshot BEFORE"
         run: |

--- a/.github/workflows/npm-outdated.yml
+++ b/.github/workflows/npm-outdated.yml
@@ -4,6 +4,10 @@ permissions:
   contents: write
   pull-requests: write
 
+defaults:
+  run:
+    shell: bash
+
 on:
   schedule:
     - cron: '0 1 * * 1'   # 每週一 01:00 UTC
@@ -33,6 +37,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          HUSKY: '0'
 
       # 僅手動且勾選 run_e2e 時，安裝瀏覽器並跑本地 @ui（不需要 secrets）
       - name: Install Playwright browsers

--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -13,6 +13,10 @@ permissions:
   contents: write
   pull-requests: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   predeploy:
     name: Run predeploy suite
@@ -35,25 +39,29 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          HUSKY: '0'
 
       - name: Write ~/.clasprc.json
         env:
           CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
         run: |
+          bash -eo pipefail <<'BASH'
           set -euo pipefail
-          [ -n "${CLASPRC_JSON:-}" ] || { echo "::error::Missing CLASPRC_JSON"; exit 1; }
+          : "${CLASPRC_JSON:?Missing CLASPRC_JSON}"
           node -e "
-            const fs=require('fs');const path=require('path');
-            const target=path.join(process.env.HOME||require('os').homedir(),'.clasprc.json');
-            let s=process.env.CLASPRC_JSON||'';let j;
-            try{ j=JSON.parse(s); }
-            catch(e){ s=s.replace(/\s+/g,''); j=JSON.parse(Buffer.from(s,'base64').toString()); }
-            if(!j.token && j.tokens && j.tokens.default){ j.token=j.tokens.default; }
-            fs.mkdirSync(path.dirname(target),{recursive:true});
-            fs.writeFileSync(target, JSON.stringify(j,null,2));
+            const fs=require('fs'), path=require('path');
+            const p=process.env.HOME+'/.clasprc.json';
+            let s=process.env.CLASPRC_JSON||''; let j;
+            try { j=JSON.parse(s); }
+            catch (e) { s=s.replace(/\s+/g,''); j=JSON.parse(Buffer.from(s,'base64').toString()); }
+            if(!j.token && j.tokens?.default) j.token=j.tokens.default;
+            fs.mkdirSync(path.dirname(p), {recursive:true});
+            fs.writeFileSync(p, JSON.stringify(j,null,2));
           "
           test -s "$HOME/.clasprc.json"
           cp "$HOME/.clasprc.json" "$GITHUB_WORKSPACE/.clasprc.json"
+          BASH
 
       - name: Create GAS version (prod)
         id: ver_prod


### PR DESCRIPTION
## Summary
- ensure `ci-preview`, `predeploy`, and `npm-outdated` run steps use bash by default and share the clasp writer here-doc
- add `HUSKY=0` to every `npm ci` invocation to avoid husky side-effects in CI jobs
- reuse the safer clasp token writer across `gas-deploy` jobs and keep the `?route=AA01` E2E fallback

## Testing
- npm run lint
- npm run test
- npm run e2e
- npm run health *(fails: HEALTH_CHECK_ERROR against https://example.com/)*

------
https://chatgpt.com/codex/tasks/task_e_68df93b994a0832b98554003fd921377