### PR TITLE
chore: enforce bash strict mode in workflows

### DIFF
--- a/.github/workflows/ci-preview.yml
+++ b/.github/workflows/ci-preview.yml
@@ -16,7 +16,7 @@ permissions:
 
 defaults:
   run:
-    shell: bash
+    shell: bash {0}
 
 jobs:
   preview:
@@ -53,27 +53,31 @@ jobs:
         env:
           CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
         run: |
-          bash -eo pipefail <<'BASH'
           set -euo pipefail
           : "${CLASPRC_JSON:?Missing CLASPRC_JSON}"
-          node -e "
-            const fs=require('fs'), path=require('path');
-            const p=process.env.HOME+'/.clasprc.json';
-            let s=process.env.CLASPRC_JSON||''; let j;
-            try { j=JSON.parse(s); }
-            catch (e) { s=s.replace(/\s+/g,''); j=JSON.parse(Buffer.from(s,'base64').toString()); }
-            if(!j.token && j.tokens?.default) j.token=j.tokens.default;
-            fs.mkdirSync(path.dirname(p), {recursive:true});
-            fs.writeFileSync(p, JSON.stringify(j,null,2));
-          "
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const p = process.env.HOME + '/.clasprc.json';
+          let s = process.env.CLASPRC_JSON || '';
+          let j;
+          try {
+            j = JSON.parse(s);
+          } catch (e) {
+            s = s.replace(/\s+/g, '');
+            j = JSON.parse(Buffer.from(s, 'base64').toString());
+          }
+          if (!j.token && j.tokens?.default) j.token = j.tokens.default;
+          fs.mkdirSync(path.dirname(p), { recursive: true });
+          fs.writeFileSync(p, JSON.stringify(j, null, 2));
+          NODE
           test -s "$HOME/.clasprc.json"
           cp "$HOME/.clasprc.json" "$GITHUB_WORKSPACE/.clasprc.json"
-          BASH
 
       - name: Create GAS version
         id: ver
         run: |
-          set -e
+          set -euo pipefail
           npx clasp version "ci:${GITHUB_SHA::7}" || true
           VER=$(npx clasp versions | awk '/^@/ {v=$2} END{print v}')
           [ -n "$VER" ] || (echo "No version found"; exit 1)

--- a/.github/workflows/gas-deploy.yml
+++ b/.github/workflows/gas-deploy.yml
@@ -17,7 +17,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash {0}
 
 jobs:
   unit-tests:
@@ -92,6 +92,7 @@ jobs:
       - name: Restore Playwright auth state
         if: ${{ env.HAS_AUTH == 'true' }}
         run: |
+          set -euo pipefail
           echo "${PLAYWRIGHT_AUTH_STATE_B64}" | base64 -d > auth.json
           echo "auth.json restored"
 
@@ -122,6 +123,7 @@ jobs:
           LOCAL_BASE_URL: ${{ env.LOCAL_BASE_URL }}
       - name: Debug secrets → env mapping
         run: |
+          set -euo pipefail
           node -e "process.stdout.write('GAS_WEBAPP_URL length=' + String((process.env.GAS_WEBAPP_URL || '').length))"
 
       - name: Health check (200/302 or skip)
@@ -167,26 +169,30 @@ jobs:
         env:
           CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
         run: |
-          bash -eo pipefail <<'BASH'
           set -euo pipefail
           : "${CLASPRC_JSON:?Missing CLASPRC_JSON}"
-          node -e "
-            const fs=require('fs'), path=require('path');
-            const p=process.env.HOME+'/.clasprc.json';
-            let s=process.env.CLASPRC_JSON||''; let j;
-            try { j=JSON.parse(s); }
-            catch (e) { s=s.replace(/\s+/g,''); j=JSON.parse(Buffer.from(s,'base64').toString()); }
-            if(!j.token && j.tokens?.default) j.token=j.tokens.default;
-            fs.mkdirSync(path.dirname(p), {recursive:true});
-            fs.writeFileSync(p, JSON.stringify(j,null,2));
-          "
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const p = process.env.HOME + '/.clasprc.json';
+          let s = process.env.CLASPRC_JSON || '';
+          let j;
+          try {
+            j = JSON.parse(s);
+          } catch (e) {
+            s = s.replace(/\s+/g, '');
+            j = JSON.parse(Buffer.from(s, 'base64').toString());
+          }
+          if (!j.token && j.tokens?.default) j.token = j.tokens.default;
+          fs.mkdirSync(path.dirname(p), { recursive: true });
+          fs.writeFileSync(p, JSON.stringify(j, null, 2));
+          NODE
           test -s "$HOME/.clasprc.json"
           cp "$HOME/.clasprc.json" "$GITHUB_WORKSPACE/.clasprc.json"
-          BASH
 
       - name: "Preflight: check TEST secrets & clasp & script"
         run: |
-          set -e
+          set -euo pipefail
 
           echo "=== 1) Secrets 注入 ==="
           echo "TEST_DEPLOYMENT_ID len: ${#TEST_DEPLOYMENT_ID}"
@@ -220,6 +226,7 @@ jobs:
 
       - name: "Guard: appsscript.json must declare webapp"
         run: |
+          set -euo pipefail
           node - <<'EOF'
           const fs = require('fs');
           const path = require('path');
@@ -278,7 +285,7 @@ jobs:
       # BEFORE snapshot（文字解析 fallback）
       - name: "Snapshot BEFORE"
         run: |
-          set -e
+          set -euo pipefail
           clasp deployments > before.txt || true
           clasp deployments --json > before.json || true
           node -e "
@@ -324,6 +331,7 @@ jobs:
         env:
           TEST_DEPLOYMENT_ID: ${{ secrets.TEST_DEPLOYMENT_ID }}
         run: |
+          set -euo pipefail
           if [ -z "${TEST_DEPLOYMENT_ID:-}" ]; then
             echo "::warning::TEST_DEPLOYMENT_ID secret is not available for this workflow run."
             echo "has_secret=false" >> "$GITHUB_OUTPUT"
@@ -336,6 +344,7 @@ jobs:
         env:
           TEST_DEPLOYMENT_ID: ${{ secrets.TEST_DEPLOYMENT_ID }}
         run: |
+          set -euo pipefail
           node -e "
             const fs=require('fs');
             const hasOwn=Object.prototype.hasOwnProperty;
@@ -359,7 +368,7 @@ jobs:
         env:
           SHA: ${{ github.sha }}
         run: |
-          set -e
+          set -euo pipefail
           SHORT_SHA="${SHA::7}"
           cat > 00_ci_env.gs <<EOF
           const CI_ENV = 'TEST';
@@ -372,7 +381,7 @@ jobs:
       - name: "Create new version (TEST)"
         id: mkver-test
         run: |
-          set -e
+          set -euo pipefail
           out=$(clasp version "[TEST] CI ${GITHUB_SHA::7}" || true)
           echo "$out"
           ver=$(echo "$out" | sed -n "s/Created version \([0-9][0-9]*\).*/\1/p")
@@ -385,7 +394,7 @@ jobs:
         env:
           TEST_DEPLOYMENT_ID: ${{ secrets.TEST_DEPLOYMENT_ID }}
         run: |
-          set -e
+          set -euo pipefail
           [ -n "${TEST_DEPLOYMENT_ID:-}" ] || { echo "::error::Missing TEST_DEPLOYMENT_ID"; exit 1; }
           [ -n "${NEW_VER:-}" ] || { echo "::error::Missing NEW_VER"; exit 1; }
           clasp deploy --deploymentId "$TEST_DEPLOYMENT_ID" --versionNumber "$NEW_VER" -d "[TEST] CI ${GITHUB_SHA::7}"
@@ -395,7 +404,7 @@ jobs:
         env:
           TEST_DEPLOYMENT_ID: ${{ secrets.TEST_DEPLOYMENT_ID }}
         run: |
-          set -e
+          set -euo pipefail
           clasp deployments > after.txt || true
           clasp deployments --json > after.json || true
           node -e "
@@ -452,6 +461,7 @@ jobs:
         env:
           TEST_DEPLOYMENT_ID: ${{ secrets.TEST_DEPLOYMENT_ID }}
         run: |
+          set -euo pipefail
           if [ -n "${TEST_DEPLOYMENT_ID:-}" ]; then
             echo "len=${#TEST_DEPLOYMENT_ID}"
           else
@@ -480,7 +490,7 @@ jobs:
         env:
           TEST_DEPLOYMENT_ID: ${{ secrets.TEST_DEPLOYMENT_ID }}
         run: |
-          set -e
+          set -euo pipefail
           URL="https://script.google.com/macros/s/${TEST_DEPLOYMENT_ID}/exec?route=health&v=${GITHUB_SHA::7}"
           code=$(curl -sS -o /dev/null -w "%{http_code}" -D headers.txt "$URL" || true)
           loc=$(awk 'BEGIN{IGNORECASE=1}/^Location:/{print $2}' headers.txt | tr -d '\r\n')
@@ -515,26 +525,30 @@ jobs:
         env:
           CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
         run: |
-          bash -eo pipefail <<'BASH'
           set -euo pipefail
           : "${CLASPRC_JSON:?Missing CLASPRC_JSON}"
-          node -e "
-            const fs=require('fs'), path=require('path');
-            const p=process.env.HOME+'/.clasprc.json';
-            let s=process.env.CLASPRC_JSON||''; let j;
-            try { j=JSON.parse(s); }
-            catch (e) { s=s.replace(/\s+/g,''); j=JSON.parse(Buffer.from(s,'base64').toString()); }
-            if(!j.token && j.tokens?.default) j.token=j.tokens.default;
-            fs.mkdirSync(path.dirname(p), {recursive:true});
-            fs.writeFileSync(p, JSON.stringify(j,null,2));
-          "
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const p = process.env.HOME + '/.clasprc.json';
+          let s = process.env.CLASPRC_JSON || '';
+          let j;
+          try {
+            j = JSON.parse(s);
+          } catch (e) {
+            s = s.replace(/\s+/g, '');
+            j = JSON.parse(Buffer.from(s, 'base64').toString());
+          }
+          if (!j.token && j.tokens?.default) j.token = j.tokens.default;
+          fs.mkdirSync(path.dirname(p), { recursive: true });
+          fs.writeFileSync(p, JSON.stringify(j, null, 2));
+          NODE
           test -s "$HOME/.clasprc.json"
           cp "$HOME/.clasprc.json" "$GITHUB_WORKSPACE/.clasprc.json"
-          BASH
 
       - name: "Snapshot BEFORE"
         run: |
-          set -e
+          set -euo pipefail
           clasp deployments > before.txt || true
           clasp deployments --json > before.json || true
           node -e "
@@ -579,6 +593,7 @@ jobs:
         env:
           GAS_DEPLOYMENT_ID: ${{ secrets.GAS_DEPLOYMENT_ID }}
         run: |
+          set -euo pipefail
           node -e "
             const fs=require('fs');
             const hasOwn=Object.prototype.hasOwnProperty;
@@ -601,7 +616,7 @@ jobs:
         env:
           SHA: ${{ github.sha }}
         run: |
-          set -e
+          set -euo pipefail
           SHORT_SHA="${SHA::7}"
           cat > 00_ci_env.gs <<EOF
           const CI_ENV = 'PROD';
@@ -614,7 +629,7 @@ jobs:
       - name: "Create new version (PROD)"
         id: mkver-prod
         run: |
-          set -e
+          set -euo pipefail
           out=$(clasp version "[PROD] CI ${GITHUB_SHA::7}" || true)
           echo "$out"
           ver=$(echo "$out" | sed -n "s/Created version \([0-9][0-9]*\).*/\1/p")
@@ -626,7 +641,7 @@ jobs:
         env:
           GAS_DEPLOYMENT_ID: ${{ secrets.GAS_DEPLOYMENT_ID }}
         run: |
-          set -e
+          set -euo pipefail
           [ -n "${GAS_DEPLOYMENT_ID:-}" ] || { echo "::error::Missing GAS_DEPLOYMENT_ID"; exit 1; }
           [ -n "${NEW_VER:-}" ] || { echo "::error::Missing NEW_VER"; exit 1; }
           clasp deploy --deploymentId "$GAS_DEPLOYMENT_ID" --versionNumber "$NEW_VER" -d "[PROD] CI ${GITHUB_SHA::7}"
@@ -635,7 +650,7 @@ jobs:
         env:
           GAS_DEPLOYMENT_ID: ${{ secrets.GAS_DEPLOYMENT_ID }}
         run: |
-          set -e
+          set -euo pipefail
 
           clasp deployments > after.txt || true
           clasp deployments --json > after.json || true
@@ -693,7 +708,7 @@ jobs:
         env:
           GAS_DEPLOYMENT_ID: ${{ secrets.GAS_DEPLOYMENT_ID }}
         run: |
-          set -e
+          set -euo pipefail
           URL="https://script.google.com/macros/s/${GAS_DEPLOYMENT_ID}/exec?route=health&v=${GITHUB_SHA::7}"
           code=$(curl -sS -o /dev/null -w "%{http_code}" -D headers.txt "$URL" || true)
           loc=$(awk 'BEGIN{IGNORECASE=1}/^Location:/{print $2}' headers.txt | tr -d '\r\n')

--- a/.github/workflows/npm-auto-upgrade.yml
+++ b/.github/workflows/npm-auto-upgrade.yml
@@ -4,6 +4,10 @@ permissions:
 
 name: npm auto upgrade
 
+defaults:
+  run:
+    shell: bash {0}
+
 on:
   schedule:
     - cron: '30 1 * * 1'
@@ -52,6 +56,7 @@ jobs:
       - name: Run major updates with npm-check-updates
         if: ${{ env.STRATEGY == 'major' }}
         run: |
+          set -euo pipefail
           npx npm-check-updates@latest --target=latest -u
           npm install --no-audit --no-fund
 
@@ -94,6 +99,7 @@ jobs:
 
       - name: Build upgrade summary
         run: |
+          set -euo pipefail
           node --input-type=module <<'NODE'
           import fs from 'node:fs';
           const load = path => {
@@ -127,6 +133,7 @@ jobs:
 
       - name: Validate PR token permissions
         run: |
+          set -euo pipefail
           if [ "${PR_TOKEN}" = "" ]; then
             echo "::error::PR token is not configured. Set the NPM_UPGRADE_TOKEN secret with a token that has repo scope."
             exit 1

--- a/.github/workflows/npm-outdated.yml
+++ b/.github/workflows/npm-outdated.yml
@@ -6,7 +6,7 @@ permissions:
 
 defaults:
   run:
-    shell: bash
+    shell: bash {0}
 
 on:
   schedule:
@@ -62,10 +62,12 @@ jobs:
 
       - name: Generate outdated.json
         run: |
+          set -euo pipefail
           npm outdated --json > outdated.json || true
 
       - name: Publish summary
         run: |
+          set -euo pipefail
           node --input-type=module <<'NODE'
           import fs from 'node:fs';
           const out = process.env.GITHUB_STEP_SUMMARY;

--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -15,7 +15,7 @@ permissions:
 
 defaults:
   run:
-    shell: bash
+    shell: bash {0}
 
 jobs:
   predeploy:
@@ -51,27 +51,31 @@ jobs:
         env:
           CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
         run: |
-          bash -eo pipefail <<'BASH'
           set -euo pipefail
           : "${CLASPRC_JSON:?Missing CLASPRC_JSON}"
-          node -e "
-            const fs=require('fs'), path=require('path');
-            const p=process.env.HOME+'/.clasprc.json';
-            let s=process.env.CLASPRC_JSON||''; let j;
-            try { j=JSON.parse(s); }
-            catch (e) { s=s.replace(/\s+/g,''); j=JSON.parse(Buffer.from(s,'base64').toString()); }
-            if(!j.token && j.tokens?.default) j.token=j.tokens.default;
-            fs.mkdirSync(path.dirname(p), {recursive:true});
-            fs.writeFileSync(p, JSON.stringify(j,null,2));
-          "
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const p = process.env.HOME + '/.clasprc.json';
+          let s = process.env.CLASPRC_JSON || '';
+          let j;
+          try {
+            j = JSON.parse(s);
+          } catch (e) {
+            s = s.replace(/\s+/g, '');
+            j = JSON.parse(Buffer.from(s, 'base64').toString());
+          }
+          if (!j.token && j.tokens?.default) j.token = j.tokens.default;
+          fs.mkdirSync(path.dirname(p), { recursive: true });
+          fs.writeFileSync(p, JSON.stringify(j, null, 2));
+          NODE
           test -s "$HOME/.clasprc.json"
           cp "$HOME/.clasprc.json" "$GITHUB_WORKSPACE/.clasprc.json"
-          BASH
 
       - name: Create GAS version (prod)
         id: ver_prod
         run: |
-          set -e
+          set -euo pipefail
           npx clasp version "prod:${GITHUB_SHA::7}" || true
           VER=$(npx clasp versions | awk '/^@/ {v=$2} END{print v}')
           [ -n "$VER" ] || (echo "No version found"; exit 1)
@@ -84,6 +88,7 @@ jobs:
       - name: Restore auth (and debug)
         if: ${{ env.HAS_AUTH == 'true' }}
         run: |
+          set -euo pipefail
           echo "${{ secrets.PLAYWRIGHT_AUTH_STATE }}" | base64 -d > auth.json
           echo "auth.json restored"; ls -l auth.json
 


### PR DESCRIPTION
## Summary
- set `defaults.run.shell` to `bash {0}` across the CI workflows so Bash strict options are consistently available
- prefixed every multi-line run block with `set -euo pipefail` and replaced ad-hoc subshell invocations with direct scripts under the new defaults

## Testing
- npm run lint
- npm run test
- npm run e2e

------
https://chatgpt.com/codex/tasks/task_e_68dfb6a5bf28832b8703efaf934889d7