### PR TITLE
chore: install Playwright browsers in upgrade workflow

### DIFF
--- a/.github/workflows/npm-auto-upgrade.yml
+++ b/.github/workflows/npm-auto-upgrade.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install dependencies
         run: npm install --no-audit --no-fund
 
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
       - name: Capture outdated (before)
         run: npm outdated --json > before.json || true
 


### PR DESCRIPTION
## Summary
- install Playwright browsers before running npm auto upgrade E2E smoke tests to ensure host runners have required binaries

## Testing
- npm run lint
- npm run test
- npm run e2e

## Acceptance Report
- Summary: Playwright browsers are installed natively in the npm auto upgrade workflow so the host runner can execute Playwright smoke checks without the container; local lint, unit, and E2E suites succeeded.
- Full report: included in the task completion message.

------
https://chatgpt.com/codex/tasks/task_e_68dfbf587d54832ba027a610d91a107e