### PR TITLE
fix(ci): simplify clasp credential handling

### DIFF
--- a/.github/workflows/ci-preview.yml
+++ b/.github/workflows/ci-preview.yml
@@ -54,24 +54,17 @@ jobs:
           CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
         run: |
           set -euo pipefail
-          : "${CLASPRC_JSON:?Missing CLASPRC_JSON}"
-          node <<'NODE'
-          const fs = require('fs');
-          const path = require('path');
-          const p = process.env.HOME + '/.clasprc.json';
-          let s = process.env.CLASPRC_JSON || '';
-          let j;
-          try {
-            j = JSON.parse(s);
-          } catch (e) {
-            s = s.replace(/\s+/g, '');
-            j = JSON.parse(Buffer.from(s, 'base64').toString());
-          }
-          if (!j.token && j.tokens?.default) j.token = j.tokens.default;
-          fs.mkdirSync(path.dirname(p), { recursive: true });
-          fs.writeFileSync(p, JSON.stringify(j, null, 2));
-          NODE
-          test -s "$HOME/.clasprc.json"
+          if [[ -z "${CLASPRC_JSON:-}" ]]; then
+            echo "Error: CLASPRC_JSON is empty or not set!" >&2
+            exit 1
+          fi
+          mkdir -p "$HOME"
+          if [[ "${CLASPRC_JSON:0:1}" == "{" ]]; then
+            printf '%s' "$CLASPRC_JSON" > "$HOME/.clasprc.json"
+          else
+            echo "$CLASPRC_JSON" | tr -d '[:space:]' | base64 -d > "$HOME/.clasprc.json"
+          fi
+          test -s "$HOME/.clasprc.json" || { echo "Failed to write ~/.clasprc.json" >&2; exit 1; }
           cp "$HOME/.clasprc.json" "$GITHUB_WORKSPACE/.clasprc.json"
 
       - name: Create GAS version

--- a/.github/workflows/gas-deploy.yml
+++ b/.github/workflows/gas-deploy.yml
@@ -170,24 +170,17 @@ jobs:
           CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
         run: |
           set -euo pipefail
-          : "${CLASPRC_JSON:?Missing CLASPRC_JSON}"
-          node <<'NODE'
-          const fs = require('fs');
-          const path = require('path');
-          const p = process.env.HOME + '/.clasprc.json';
-          let s = process.env.CLASPRC_JSON || '';
-          let j;
-          try {
-            j = JSON.parse(s);
-          } catch (e) {
-            s = s.replace(/\s+/g, '');
-            j = JSON.parse(Buffer.from(s, 'base64').toString());
-          }
-          if (!j.token && j.tokens?.default) j.token = j.tokens.default;
-          fs.mkdirSync(path.dirname(p), { recursive: true });
-          fs.writeFileSync(p, JSON.stringify(j, null, 2));
-          NODE
-          test -s "$HOME/.clasprc.json"
+          if [[ -z "${CLASPRC_JSON:-}" ]]; then
+            echo "Error: CLASPRC_JSON is empty or not set!" >&2
+            exit 1
+          fi
+          mkdir -p "$HOME"
+          if [[ "${CLASPRC_JSON:0:1}" == "{" ]]; then
+            printf '%s' "$CLASPRC_JSON" > "$HOME/.clasprc.json"
+          else
+            echo "$CLASPRC_JSON" | tr -d '[:space:]' | base64 -d > "$HOME/.clasprc.json"
+          fi
+          test -s "$HOME/.clasprc.json" || { echo "Failed to write ~/.clasprc.json" >&2; exit 1; }
           cp "$HOME/.clasprc.json" "$GITHUB_WORKSPACE/.clasprc.json"
 
       - name: "Preflight: check TEST secrets & clasp & script"
@@ -526,24 +519,17 @@ jobs:
           CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
         run: |
           set -euo pipefail
-          : "${CLASPRC_JSON:?Missing CLASPRC_JSON}"
-          node <<'NODE'
-          const fs = require('fs');
-          const path = require('path');
-          const p = process.env.HOME + '/.clasprc.json';
-          let s = process.env.CLASPRC_JSON || '';
-          let j;
-          try {
-            j = JSON.parse(s);
-          } catch (e) {
-            s = s.replace(/\s+/g, '');
-            j = JSON.parse(Buffer.from(s, 'base64').toString());
-          }
-          if (!j.token && j.tokens?.default) j.token = j.tokens.default;
-          fs.mkdirSync(path.dirname(p), { recursive: true });
-          fs.writeFileSync(p, JSON.stringify(j, null, 2));
-          NODE
-          test -s "$HOME/.clasprc.json"
+          if [[ -z "${CLASPRC_JSON:-}" ]]; then
+            echo "Error: CLASPRC_JSON is empty or not set!" >&2
+            exit 1
+          fi
+          mkdir -p "$HOME"
+          if [[ "${CLASPRC_JSON:0:1}" == "{" ]]; then
+            printf '%s' "$CLASPRC_JSON" > "$HOME/.clasprc.json"
+          else
+            echo "$CLASPRC_JSON" | tr -d '[:space:]' | base64 -d > "$HOME/.clasprc.json"
+          fi
+          test -s "$HOME/.clasprc.json" || { echo "Failed to write ~/.clasprc.json" >&2; exit 1; }
           cp "$HOME/.clasprc.json" "$GITHUB_WORKSPACE/.clasprc.json"
 
       - name: "Snapshot BEFORE"

--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -52,24 +52,17 @@ jobs:
           CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
         run: |
           set -euo pipefail
-          : "${CLASPRC_JSON:?Missing CLASPRC_JSON}"
-          node <<'NODE'
-          const fs = require('fs');
-          const path = require('path');
-          const p = process.env.HOME + '/.clasprc.json';
-          let s = process.env.CLASPRC_JSON || '';
-          let j;
-          try {
-            j = JSON.parse(s);
-          } catch (e) {
-            s = s.replace(/\s+/g, '');
-            j = JSON.parse(Buffer.from(s, 'base64').toString());
-          }
-          if (!j.token && j.tokens?.default) j.token = j.tokens.default;
-          fs.mkdirSync(path.dirname(p), { recursive: true });
-          fs.writeFileSync(p, JSON.stringify(j, null, 2));
-          NODE
-          test -s "$HOME/.clasprc.json"
+          if [[ -z "${CLASPRC_JSON:-}" ]]; then
+            echo "Error: CLASPRC_JSON is empty or not set!" >&2
+            exit 1
+          fi
+          mkdir -p "$HOME"
+          if [[ "${CLASPRC_JSON:0:1}" == "{" ]]; then
+            printf '%s' "$CLASPRC_JSON" > "$HOME/.clasprc.json"
+          else
+            echo "$CLASPRC_JSON" | tr -d '[:space:]' | base64 -d > "$HOME/.clasprc.json"
+          fi
+          test -s "$HOME/.clasprc.json" || { echo "Failed to write ~/.clasprc.json" >&2; exit 1; }
           cp "$HOME/.clasprc.json" "$GITHUB_WORKSPACE/.clasprc.json"
 
       - name: Create GAS version (prod)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ AA01 是一套以 Google Apps Script 打造的 Google 文件附加功能。長�
    export GAS_CLIENT_SECRET="<桌面 OAuth Client Secret>"
    export GAS_OAUTH_REFRESH_TOKEN="<剛取得的 refresh_token>"
    ```
+
+### CLASPRC_JSON Secret 管理
+
+- GitHub Actions 的 `CLASPRC_JSON` Secret 必須維持為 **完整的 `.clasprc.json`**，可以直接貼上 JSON 文字，或先轉為 Base64 字串後存入 Secret。請選擇一種格式並保持一致，避免混淆。
+- 若提供 Base64 字串，請確保沒有多餘換行；若提供 JSON 文字，請確認內容與本機 `.clasprc.json` 完整一致（含 `token` / `tokens.default` 欄位）。
+- 憑證過期時請使用 `clasp login --no-localhost` 重新取得新的 `.clasprc.json`，並立即更新 Secret。建議於每次部署失敗出現 `invalid_grant` 時優先檢查這項設定。
+- 在更新 Secret 後，可本地或於 CI 中執行 `npx clasp auth status`（或 `clasp whoami`）確認登入狀態正常，確保部署流程不會因憑證過期中斷。
+
 4. **同步程式並建立 Web App Deployment**
    - 於專案根目錄執行 `npm install`（首次使用時）。
    - 以 `npm run deploy:web` 觸發 `gas-deploy.mjs`：此指令會依序呼叫 `projects.updateContent`、建立版本並更新（或建立）部署。成功後終端機會顯示最新的 Web App URL。


### PR DESCRIPTION
## Summary
- replace the Node-based clasp credential writer in deployment workflows with a bash implementation that supports JSON or base64 secrets and validates the file
- document how to manage the CLASPRC_JSON secret so that CI credentials remain current

## Testing
- npm run lint
- npm run test
- npm run e2e


------
https://chatgpt.com/codex/tasks/task_e_68dfbfda0334832b82f6408d078fd54b