### PR TITLE
fix: remove duplicate artifact index step

### DIFF
--- a/.github/workflows/gas-deploy.yml
+++ b/.github/workflows/gas-deploy.yml
@@ -143,15 +143,6 @@ jobs:
             artifacts
           ARTIFACT_INDEX_PATH: artifacts/index.json
 
-      - name: Build artifact index
-        if: always()
-        run: node scripts/build-artifact-index.mjs
-        env:
-          ARTIFACT_SOURCES: |
-            playwright-report
-            artifacts
-          ARTIFACT_INDEX_PATH: artifacts/index.json
-
       - uses: actions/upload-artifact@v4
         if: always()
         with:


### PR DESCRIPTION
## Summary
- remove the duplicate Build artifact index step in the test-stage job so only one index is built before uploading artifacts

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e` *(fails: Playwright browsers not installed in container; installing dependencies would require ~500 MB system packages)*
- `gh workflow view gas-deploy.yml --json name,path` *(fails: installed gh v2.45.0 does not support --json flag without authenticating repo)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc5eb4c1c832b8d88133f2e1a87e1