### PR TITLE
Add Playwright browser cache to CI preview workflow

### DIFF
--- a/.github/workflows/ci-preview.yml
+++ b/.github/workflows/ci-preview.yml
@@ -46,6 +46,14 @@ jobs:
         env:
           HUSKY: '0'
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
       - name: Install Playwright dependencies
         run: npx playwright install --with-deps
 


### PR DESCRIPTION
## Summary
- add an `actions/cache` step for the Playwright browser directory in the CI preview workflow
- keep the existing `npx playwright install --with-deps` step immediately after the cache so restored browsers are reused

## Testing
- npm run lint
- npm run test
- npm run e2e

------
https://chatgpt.com/codex/tasks/task_e_68dfc84c1054832b9de01a13714dc66b