### PR TITLE
chore: disable husky hooks in CI workflows

### DIFF
--- a/.github/workflows/ci-preview.yml
+++ b/.github/workflows/ci-preview.yml
@@ -1,4 +1,9 @@
 name: ci-preview
+
+env:
+  CI: true
+  HUSKY: 0
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/gas-deploy.yml
+++ b/.github/workflows/gas-deploy.yml
@@ -1,5 +1,9 @@
 name: GAS staged test & deploy (single workflow)
 
+env:
+  CI: true
+  HUSKY: 0
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/npm-auto-upgrade.yml
+++ b/.github/workflows/npm-auto-upgrade.yml
@@ -4,6 +4,10 @@ permissions:
 
 name: npm auto upgrade
 
+env:
+  CI: true
+  HUSKY: 0
+
 defaults:
   run:
     shell: bash {0}

--- a/.github/workflows/npm-outdated.yml
+++ b/.github/workflows/npm-outdated.yml
@@ -1,5 +1,9 @@
 name: npm outdated report
 
+env:
+  CI: true
+  HUSKY: 0
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -1,5 +1,9 @@
 name: predeploy quality gate
 
+env:
+  CI: true
+  HUSKY: 0
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
## Summary
- add CI=true and HUSKY=0 environment variables at the workflow level for every GitHub Actions pipeline
- ensure npm install steps skip Husky hook installation across lint, test, deploy, and maintenance workflows

## Testing
- npm run lint
- npm run test
- npm run e2e


------
https://chatgpt.com/codex/tasks/task_e_68dfd9c5b9b4832bac93922f3757221d