### PR TITLE
[fix-ci] Improve health check proxy resilience

### DIFF
--- a/scripts/health-check.mjs
+++ b/scripts/health-check.mjs
@@ -1,7 +1,40 @@
 #!/usr/bin/env node
 import 'dotenv/config';
 import process from 'node:process';
+import { ProxyAgent } from 'undici';
 import { buildTargetURL, safeWriteJson } from './url-helper.mjs';
+
+const proxyUrl = process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY;
+const proxyDispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined;
+
+function hasProxyTunnelFailure(error) {
+  let current = error;
+  while (current && typeof current === 'object') {
+    if (
+      typeof current.message === 'string' &&
+      current.message.includes('Proxy response') &&
+      current.message.includes('HTTP Tunneling')
+    ) {
+      return true;
+    }
+    current = current.cause;
+  }
+  return false;
+}
+
+async function fetchWithProxy(targetUrl) {
+  try {
+    return await fetch(targetUrl, {
+      redirect: 'manual',
+      dispatcher: proxyDispatcher
+    });
+  } catch (error) {
+    if (proxyDispatcher && error instanceof Error && hasProxyTunnelFailure(error)) {
+      return fetch(targetUrl, { redirect: 'manual' });
+    }
+    throw error;
+  }
+}
 
 async function main() {
   const base = process.env.GAS_WEBAPP_URL;
@@ -11,7 +44,7 @@ async function main() {
   console.info(`HEALTH_TARGET_URL=${target.href}`);
   safeWriteJson('artifacts/health-url.json', target);
 
-  const response = await fetch(target.href, { redirect: 'manual' });
+  const response = await fetchWithProxy(target.href);
   const bodyText = await response.text();
 
   const summary = {
@@ -34,7 +67,13 @@ async function main() {
 }
 
 main().catch(error => {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error('HEALTH_CHECK_ERROR:', message);
+  if (error instanceof Error) {
+    console.error('HEALTH_CHECK_ERROR:', error.message);
+    if (error.cause) {
+      console.error('HEALTH_CHECK_CAUSE:', error.cause);
+    }
+  } else {
+    console.error('HEALTH_CHECK_ERROR:', String(error));
+  }
   process.exitCode = 1;
 });


### PR DESCRIPTION
## Summary
- add Undici proxy agent support in the health check script so CI can operate behind corporate proxies
- retry the request without the proxy when HTTP tunneling is rejected and surface detailed error causes for troubleshooting

## Testing
- npm run lint
- npm run test
- npm run e2e

## Duplicate Code Report
- Not available (no duplication tooling configured)


------
https://chatgpt.com/codex/tasks/task_e_68e014886ca0832b8209d1f1d3369557