### PR TITLE
refactor: repository audit (codex-controlled)

### DIFF
--- a/.github/workflows/codex-audit.yml
+++ b/.github/workflows/codex-audit.yml
@@ -1,23 +1,30 @@
-name: Codex Audit Placeholder
-
+name: codex-audit
 on:
+  issue_comment:
+    types: [created]
   workflow_dispatch:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-
 jobs:
   audit:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.comment.body, '/audit')
     runs-on: ubuntu-latest
+    timeout-minutes: 420
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-      - name: Use Node.js 20
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: 'npm' }
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck || npx tsc --noEmit
+      - run: npm run test -- --coverage
+      - run: npm run e2e || true
+      - run: npm run build
+      - run: npx depcheck || true
+      - run: npx jscpd --reporters console,html --threshold 2 || true
+      - run: npx madge --extensions ts,tsx,js,jsx --circular --warning --exit-code 1 src || true
+      - uses: actions/upload-artifact@v4
         with:
-          node-version: 20
-      - name: Placeholder audit
-        run: echo "Codex audit workflow placeholder"
+          name: audit-reports
+          path: |
+            reports/**
+            coverage/**
+            jscpd-report/**

--- a/.github/workflows/codex-audit.yml
+++ b/.github/workflows/codex-audit.yml
@@ -3,9 +3,12 @@ on:
   issue_comment:
     types: [created]
   workflow_dispatch:
+
+permissions:
+  contents: read
 jobs:
   audit:
-    if: github.event_name == 'workflow_dispatch' || contains(github.event.comment.body, '/audit')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/audit'))
     runs-on: ubuntu-latest
     timeout-minutes: 420
     steps:
@@ -28,6 +31,7 @@ jobs:
             reports/**
             coverage/**
             jscpd-report/**
+          if-no-files-found: ignore
           node-version: 20
       - name: Placeholder audit
         run: echo "Codex audit workflow placeholder"


### PR DESCRIPTION
## Summary
- add a Node.js 20 version hint for local tooling
- extend package.json with baseline typecheck/build scripts required by the audit flow
- replace the placeholder codex audit workflow with the full audit job wiring requested

## Testing
- Not run (workflow update only)

------
https://chatgpt.com/codex/tasks/task_e_68e0335bb210832b82cdf739c9776ae9