### PR TITLE
Fix Jest test mocks for NodeNext type checking

### DIFF
--- a/__tests__/playwright/openPage.test.ts
+++ b/__tests__/playwright/openPage.test.ts
@@ -7,16 +7,16 @@ const modulePath = '../../playwright/utils/openPage.ts';
 const helperPath = '../../scripts/url-helper.mjs';
 
 function createPageMock(finalUrl: string) {
-  const waitFor = jest.fn().mockResolvedValue(undefined);
+  const waitFor = jest.fn(async () => undefined);
   const locatorFactory = () => ({
     waitFor,
     first: () => ({ waitFor })
   });
 
   return {
-    setViewportSize: jest.fn().mockResolvedValue(undefined),
-    goto: jest.fn().mockResolvedValue(undefined),
-    waitForLoadState: jest.fn().mockResolvedValue(undefined),
+    setViewportSize: jest.fn(async () => undefined),
+    goto: jest.fn(async () => undefined),
+    waitForLoadState: jest.fn(async () => undefined),
     url: jest.fn(() => finalUrl),
     locator: jest.fn(locatorFactory),
     getByText: jest.fn(() => ({
@@ -26,7 +26,7 @@ function createPageMock(finalUrl: string) {
 }
 
 async function loadModule(
-  buildTargetURL: jest.Mock<BuildTarget, [string | undefined, string | undefined]>
+  buildTargetURL: jest.MockedFunction<(base?: string, path?: string) => BuildTarget>
 ) {
   jest.resetModules();
   jest.unstable_mockModule(helperPath, () => ({

--- a/__tests__/scripts/collect-ci-failures.test.ts
+++ b/__tests__/scripts/collect-ci-failures.test.ts
@@ -168,20 +168,25 @@ describe('collect-ci-failures utilities', () => {
       writeFile(templatePath, template, 'utf8')
     ]);
 
-    const logger = { info: jest.fn() };
-    await collectFailures(
-      [
-        '--results',
-        resultsPath,
-        '--report',
-        reportPath,
-        '--template',
-        templatePath,
-        '--set-output',
-        outputPath
-      ],
-      { logger }
-    );
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    try {
+      await collectFailures(
+        [
+          '--results',
+          resultsPath,
+          '--report',
+          reportPath,
+          '--template',
+          templatePath,
+          '--set-output',
+          outputPath
+        ],
+        { logger: console }
+      );
+      expect(infoSpy).toHaveBeenCalledWith('Recorded 2 failure(s).');
+    } finally {
+      infoSpy.mockRestore();
+    }
 
     const report = await readFile(reportPath, 'utf8');
     expect(report).toContain('# CI Failure Report');
@@ -193,7 +198,5 @@ describe('collect-ci-failures utilities', () => {
     const output = await readFile(outputPath, 'utf8');
     expect(output).toContain('has_failures=true');
     expect(output).toContain('has_blocking_failures=true');
-
-    expect(logger.info).toHaveBeenCalledWith('Recorded 2 failure(s).');
   });
 });

--- a/__tests__/scripts/run-ci-step.test.ts
+++ b/__tests__/scripts/run-ci-step.test.ts
@@ -115,7 +115,7 @@ describe('run-ci-step utilities', () => {
 
   test('main records skip without invoking exit', async () => {
     const file = resultsPath();
-    const exit = jest.fn();
+    const exit = jest.fn<(code?: string | number) => never>();
 
     await runCiStep(['--category', 'health', '--skip', 'No URL provided', '--results', file], {
       exit
@@ -128,7 +128,7 @@ describe('run-ci-step utilities', () => {
 
   test('main records failure for non-blocking command without exiting', async () => {
     const file = resultsPath();
-    const exit = jest.fn();
+    const exit = jest.fn<(code?: string | number) => never>();
 
     const scriptPath = join(tempDir, 'fail.mjs');
     await writeFile(scriptPath, 'console.error("a11y failure"); process.exit(1);', 'utf8');

--- a/__tests__/scripts/run-pa11y.test.ts
+++ b/__tests__/scripts/run-pa11y.test.ts
@@ -22,7 +22,7 @@ async function executeScript({
   const exitCalls: number[] = [];
 
   const exitSpy = jest.spyOn(process, 'exit').mockImplementation(code => {
-    exitCalls.push(code ?? 0);
+    exitCalls.push(typeof code === 'number' ? code : Number(code ?? 0));
     return undefined as never;
   });
   const infoSpy = jest.spyOn(console, 'info').mockImplementation(message => {


### PR DESCRIPTION
## Summary
- update the Playwright page loader tests to use async mocks and typed dependencies that align with NodeNext resolution
- replace manual global overrides with globalThis assignments and typed fetch stubs in the health check tests
- ensure CI helper and pa11y tests use type-safe console and process.exit mocks while preserving existing assertions

## Testing
- npm run typecheck
- npm test -- --runTestsByPath __tests__/playwright/openPage.test.ts __tests__/scripts/collect-ci-failures.test.ts __tests__/scripts/health-check.test.ts __tests__/scripts/run-ci-step.test.ts __tests__/scripts/run-pa11y.test.ts
- npm test -- --runTestsByPath __tests__/scripts/collect-ci-failures.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e1986d7d40832ba411e64b8e8e42f6